### PR TITLE
feat(side-bar): update social link styles for improved hover effects

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -308,15 +308,6 @@ main {
   padding-left: 7px;
 }
 
-.social-item .social-link {
-  color: var(--light-gray-70);
-  font-size: 18px;
-}
-
-.social-item .social-link:hover {
-  color: var(--light-gray);
-}
-
 /**
 * #clients 
 */

--- a/apps/web/src/components/side-bar/social-list.tsx
+++ b/apps/web/src/components/side-bar/social-list.tsx
@@ -16,10 +16,10 @@ function SocialList({ socialLinks }: SocialListProps) {
   return (
     <ul className="social-list">
       {socialLinks.map(({ url, icon: Icon, name }) => (
-        <li className="social-item" key={name}>
+        <li className="social-item hover:scale-110 hover:text-orange-yellow-crayola" key={name}>
           <Link
             href={url}
-            className="social-link"
+            className="text-light-gray-70 text-lg hover:scale-110 hover:text-orange-yellow-crayola"
             target="_blank"
             rel="noopener noreferrer"
             aria-label={name}


### PR DESCRIPTION
This pull request makes changes to the styling of social links in the sidebar component. The most important changes include removing old CSS rules and updating the component to use Tailwind CSS classes for hover effects and text styling.

Styling updates:

* [`apps/web/src/app/globals.css`](diffhunk://#diff-9cb236306aa43941defe02ae95334afcf65f6ae9abb6f999a1b4451d02956550L311-L319): Removed old CSS rules for `.social-item .social-link` and its hover state.
* [`apps/web/src/components/side-bar/social-list.tsx`](diffhunk://#diff-f26d7e405a3c44c6144e48713ff248502024b820ef031312ffc216789a12df1aL19-R22): Updated the `SocialList` component to use Tailwind CSS classes for hover effects and text styling on social links.