### PR TITLE
refactor(types): unify icon type definitions across components (#671)

### DIFF
--- a/apps/web/src/components/about/coding-stats.tsx
+++ b/apps/web/src/components/about/coding-stats.tsx
@@ -7,12 +7,13 @@ import GitHubCalendar from 'react-github-calendar';
 import { ThemeInput } from 'react-activity-calendar';
 import { Marquee } from './marquee'
 import { LuMapPin, LuZap } from "react-icons/lu";
+import type { VCardIconType } from "@/types/config";
 
 import "@/styles/about/coding-stats.css";
 
 interface TechStack {
   name: string;
-  icon: ReactIconType | OcticonsType;
+  icon: VCardIconType;
 };
 
 interface TechStacks {

--- a/apps/web/src/components/about/see-more-button.tsx
+++ b/apps/web/src/components/about/see-more-button.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
-import type { IconType as ReactIconType } from "react-icons";
-import type { Icon as OcticonsType } from "@primer/octicons-react";
 import { sendGTMEvent } from "@/components/google";
 import { ProgressBarLink } from "@/components/progress-bar";
+import type { VCardIconType } from "@/types/config";
 
 interface SeeMoreButtonProps {
   badge: string;
   path: string;
-  icon: ReactIconType | OcticonsType;
+  icon: VCardIconType;
 }
 
 // TODO: customize button onclick effect https://articles.readytowork.jp/google-analytics-in-next-js-a26cc2b28db5

--- a/apps/web/src/components/icon-box.tsx
+++ b/apps/web/src/components/icon-box.tsx
@@ -1,10 +1,9 @@
-import type { IconType as ReactIconType } from "react-icons";
-import type { Icon as OcticonsType } from "@primer/octicons-react";
+import type { VCardIconType } from "@/types/config";
 
 import "@/styles/icon-box.css";
 
 interface IconBoxProps {
-  icon: ReactIconType | OcticonsType;
+  icon: VCardIconType;
 }
 
 function IconBox({ icon: Icon }: IconBoxProps) {

--- a/apps/web/src/components/resume/icon-title.tsx
+++ b/apps/web/src/components/resume/icon-title.tsx
@@ -1,9 +1,8 @@
-import type { IconType as ReactIconType } from "react-icons";
-import type { Icon as OcticonsType } from "@primer/octicons-react";
 import IconBox from "../icon-box";
+import type { VCardIconType } from "@/types/config";
 
 interface IconTitleProps {
-  icon: ReactIconType | OcticonsType;
+  icon: VCardIconType;
   title: string;
 }
 

--- a/apps/web/src/components/side-bar/social-list.tsx
+++ b/apps/web/src/components/side-bar/social-list.tsx
@@ -1,10 +1,9 @@
 import Link from "next/link";
-import type { IconType as ReactIconType } from "react-icons";
-import type { Icon as OcticonsType } from "@primer/octicons-react";
+import type { VCardIconType } from "@/types/config";
 
 interface SocialLink {
   url: string;
-  icon: ReactIconType | OcticonsType;
+  icon: VCardIconType;
   name: string;
 }
 

--- a/apps/web/src/types/about.d.ts
+++ b/apps/web/src/types/about.d.ts
@@ -1,18 +1,16 @@
 // https://github.com/afiiif/pokemon-world/blob/main/src/types/pokemon.ts
 
-import type { Icon } from '@primer/octicons-react';
-import type { IconType as ReactIconType } from "react-icons";
-import type { Icon as OcticonsType } from "@primer/octicons-react";
+import type { VCardIconType } from "@/types/config";
 
 export type LifeStyle = {
-  icon: ReactIconType | OcticonsType;
+  icon: VCardIconType;
   title: string;
   text: string;
 }
 
 export type TechStack = {
   name: string;
-  icon: ReactIconType | OcticonsType;
+  icon: VCardIconType;
 };
 
 interface TechStacks {

--- a/apps/web/src/types/config.d.ts
+++ b/apps/web/src/types/config.d.ts
@@ -6,21 +6,16 @@ import type { GiscusProps } from "@giscus/react";
 import type { IconType as ReactIconType } from "react-icons";
 import type { Icon as OcticonsType } from "@primer/octicons-react";
 
-/**
- * Type definition for the Web app configuration.
- * 
- * @param {About} about
- * @param {Resume} resume
- */
+export type VCardIconType = ReactIconType | OcticonsType;
 
 export type SocialLink = {
   url: string;
-  icon: ReactIconType | OcticonsType;
+  icon: VCardIconType;
   name: string;
 }
 
 export type Contact = {
-  icon: ReactIconType | OcticonsType;
+  icon: VCardIconType;
   title: string;
   content?: string;
   link?: string;

--- a/apps/web/src/types/resume.d.ts
+++ b/apps/web/src/types/resume.d.ts
@@ -1,5 +1,4 @@
-import type { IconType as ReactIconType } from "react-icons";
-import type { Icon as OcticonsType } from "@primer/octicons-react";
+import type { VCardIconType } from "@/types/config";
 
 export type Resume = {
   educations: Education;
@@ -15,14 +14,14 @@ export type ResumeProps = {
   name: string;
   title: string;
   items: {
-    icon: ReactIconType | OcticonsType;
+    icon: VCardIconType;
     title: string;
     text: string;
   }[];
 };
 
 export type Education = {
-  icon: ReactIconType | OcticonsType;
+  icon: VCardIconType;
   title: string;
   items: {
     company: string;
@@ -34,7 +33,7 @@ export type Education = {
 };
 
 export type AwardLeaderships = {
-  icon: ReactIconType | OcticonsType;
+  icon: VCardIconType;
   title: string;
   items: {
     company: string;
@@ -46,7 +45,7 @@ export type AwardLeaderships = {
 };
 
 export type TeachingExperience = {
-  icon: ReactIconType | OcticonsType;
+  icon: VCardIconType;
   title: string;
   items: {
     company: string;
@@ -58,7 +57,7 @@ export type TeachingExperience = {
 };
 
 export type ProfessionalExperience = {
-  icon: ReactIconType | OcticonsType;
+  icon: VCardIconType;
   title: string;
   items: {
     company: string;


### PR DESCRIPTION
This pull request focuses on standardizing the icon type used across multiple components in the project by replacing the existing `ReactIconType` and `OcticonsType` with a new type `VCardIconType`. This change aims to streamline the codebase and ensure consistency in icon usage.

Standardizing icon types:

* [`apps/web/src/components/about/coding-stats.tsx`](diffhunk://#diff-6d8be9646908280416ac324f89937719dcad3bab27bb308a7d3a67e87ea54636R10-R16): Updated the `TechStack` interface to use `VCardIconType` instead of `ReactIconType` or `OcticonsType`.
* [`apps/web/src/components/about/see-more-button.tsx`](diffhunk://#diff-ff292fa27a177e10d5e4e4798a116653f695cad433e332366938e2f216d311aeL2-R9): Modified the `SeeMoreButtonProps` interface to use `VCardIconType` for the `icon` property.
* [`apps/web/src/components/icon-box.tsx`](diffhunk://#diff-017c3f600e5d1cb92aa3910d9c01e6304c62001b7e7d3bd68c9c69bc8a867c97L1-R6): Changed the `IconBoxProps` interface to use `VCardIconType` for the `icon` property.
* [`apps/web/src/components/resume/icon-title.tsx`](diffhunk://#diff-6c577c97f2163f466e7819fae259624e3aae8a5946110c4d7c8bbc9976a7195fL1-R5): Updated the `IconTitleProps` interface to use `VCardIconType` for the `icon` property.
* [`apps/web/src/components/side-bar/social-list.tsx`](diffhunk://#diff-f26d7e405a3c44c6144e48713ff248502024b820ef031312ffc216789a12df1aL2-R6): Modified the `SocialLink` interface to use `VCardIconType` for the `icon` property.