### PR TITLE
refactor(posts): improve header formatting and styling in post components (#699)

### DIFF
--- a/apps/web/src/app/post/[slug]/page.tsx
+++ b/apps/web/src/app/post/[slug]/page.tsx
@@ -127,7 +127,7 @@ export default async function Post(props: { params: tParams }) {
               {"Hugo's Blog"}
             </h1>
           </header>
-          <h1 className="title font-semibold text-4xl text-white-2 tracking-tighter max-w-[650px]">
+          <h1 className="font-semibold text-4xl text-white-2 max-w-[650px]">
             <MarkdownRenderer content={post.metadata.title} />
           </h1>
           <div className="flex items-center justify-between mt-4 text-sm w-full text-neutral-600 dark:text-neutral-400">

--- a/apps/web/src/components/markdown/anchor-header.tsx
+++ b/apps/web/src/components/markdown/anchor-header.tsx
@@ -1,6 +1,5 @@
 import React, { JSX } from 'react';
 import slugify from '@/lib/slugify';
-
 import { IoLink } from 'react-icons/io5';
 
 interface HeaderProps {
@@ -8,24 +7,26 @@ interface HeaderProps {
   children: React.ReactNode;
 }
 
-function AnchorHeader ({ level, children, ...props }: HeaderProps) {
+function AnchorHeader({ level, children, ...props }: HeaderProps) {
   let Tag = `h${level}` as keyof JSX.IntrinsicElements;
   let id = slugify(children?.toString() ?? '', { lower: true });
 
   let getMargins = (level: number) => {
     switch (level) {
       case 1:
-        return 'text-3xl font-bold mt-14 mb-10';
+        return 'text-3xl text-white-2 font-bold mt-14 mb-10';
       case 2:
-        return 'text-2xl font-semibold mt-12 mb-8';
+        return 'text-2xl text-white-2 font-bold mt-12 mb-8';
       case 3:
-        return 'text-xl font-medium mt-10 mb-6';
+        return 'text-xl text-white-2 font-bold mt-10 mb-6';
       case 4:
-        return 'text-lg font-medium mt-8 mb-4';
+        return 'text-lg text-white-2 font-semibold mt-8 mb-4';
       case 5:
-        return 'text-base font-medium mt-6 mb-3';
+        return 'text-base text-white-2 font-semibold mt-6 mb-3';
       case 6:
-        return 'text-sm font-medium mt-4 mb-2';
+        return 'text-sm text-white-2 font-semibold mt-4 mb-2';
+      case 7:
+        return 'text-xs text-white-2 font-semibold mt-4 mb-2';
       default:
         return '';
     }
@@ -43,7 +44,7 @@ function AnchorHeader ({ level, children, ...props }: HeaderProps) {
         href={`#${id}`}
         className="no-underline text-[#d6d6d6] hover:underline flex items-center"
       >
-        <span className="absolute left-[-1.5rem] top-[0.2rem] opacity-0 transition-opacity duration-200 ease-in-out scale-90 group-hover:opacity-100">
+        <span className="absolute left-[-2.0rem] top-[0.2rem] opacity-0 transition-opacity duration-200 ease-in-out scale-90 group-hover:opacity-100">
           <IoLink />
         </span>
       </a>

--- a/apps/web/src/contents/posts/hugo-s-go-to-stack-for-building-maintainable-software.md
+++ b/apps/web/src/contents/posts/hugo-s-go-to-stack-for-building-maintainable-software.md
@@ -18,9 +18,9 @@ Hey there 👋 This is Hugo. Here's a quick summary of my go-to tech stack for S
 
 ![Hugo's Go-To Stack for Building Software](/images/banner/posts/hugo-s-go-to-stack-for-building-maintainable-software.webp)
 
-## React
+# React
 
-### Function Components
+## Function Components
 
 We only use `FC` type when we need to pass and extract children from props [^1]. Otherwise, we use the function declaration. Refer [here](https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/function_components/) for a more extensive section explaining why `React.FC` should mostly be avoided.
 
@@ -44,9 +44,9 @@ function Heading({text = 'Hello, world!'}: Props) {
 }
 ```
 
-## Python
+# Python
 
-### Docstring and Type Hint
+## Docstring and Type Hint
 
 We must have docstring and type hint for every public class and method/function. The format of the docstring is as follows:
 
@@ -91,7 +91,7 @@ def func(arg1: int, arg2: str) -> str:
     return
 ```
 
-### Naming Convention
+## Naming Convention
 
 We follow the naming convention as follows:
 
@@ -102,9 +102,9 @@ We follow the naming convention as follows:
 5. private variable name: `_snake_case`
 6. read only constant name: `UPPER_SNAKE_CASE`
 
-## Coding Patterns
+# Coding Patterns
 
-### Larger files > many small components
+## Larger files > many small components
 
 Many people advocate for clean, modular, and maintainable code. While these principles are essential, there are drawbacks when we scale this approach to large codebases, especially those with millions of lines of code.
 


### PR DESCRIPTION
This pull request includes several updates to the styling and formatting of headers and markdown content in the `apps/web` project. The most important changes include adjustments to CSS classes for headers, the addition of a new header level, and formatting changes in markdown files.

Styling updates:

* `apps/web/src/app/post/[slug]/page.tsx`: Modified the CSS classes for the main title to remove the `title` class and adjust other classes for consistency. ([apps/web/src/app/post/[slug]/page.tsxL130-R130](diffhunk://#diff-76c9cdd9afe23e68859d782b1b1a0416e89bf28b0a263a43d42c3e4ef4854e29L130-R130))
* [`apps/web/src/components/markdown/anchor-header.tsx`](diffhunk://#diff-6d4a691edadb261982edd9910e4efb201d1d08af823c15253c1abdf3debdd24bL18-R29): Updated the CSS classes for different header levels to include `text-white-2` and made adjustments to the positioning of anchor links. Added a new header level (level 7) with specific styling. [[1]](diffhunk://#diff-6d4a691edadb261982edd9910e4efb201d1d08af823c15253c1abdf3debdd24bL18-R29) [[2]](diffhunk://#diff-6d4a691edadb261982edd9910e4efb201d1d08af823c15253c1abdf3debdd24bL46-R47)

Markdown formatting:

* [`apps/web/src/contents/posts/hugo-s-go-to-stack-for-building-maintainable-software.md`](diffhunk://#diff-4828e8126d8d2debd24c98d35ae7109590bc26a6016cfb943ca241dd84c8fa75L21-R23): Changed the markdown headers from `###` to `##` for better readability and consistency across the document. [[1]](diffhunk://#diff-4828e8126d8d2debd24c98d35ae7109590bc26a6016cfb943ca241dd84c8fa75L21-R23) [[2]](diffhunk://#diff-4828e8126d8d2debd24c98d35ae7109590bc26a6016cfb943ca241dd84c8fa75L47-R49) [[3]](diffhunk://#diff-4828e8126d8d2debd24c98d35ae7109590bc26a6016cfb943ca241dd84c8fa75L94-R94) [[4]](diffhunk://#diff-4828e8126d8d2debd24c98d35ae7109590bc26a6016cfb943ca241dd84c8fa75L105-R107)

Code cleanup:

* [`apps/web/src/components/markdown/anchor-header.tsx`](diffhunk://#diff-6d4a691edadb261982edd9910e4efb201d1d08af823c15253c1abdf3debdd24bL3): Removed an unnecessary blank line to improve code readability.