### PR TITLE
refactor(block-quote): update font size, color, and font (#703)

### DIFF
--- a/apps/web/src/components/markdown/block-quote.tsx
+++ b/apps/web/src/components/markdown/block-quote.tsx
@@ -6,10 +6,12 @@ interface BlockQuoteProps {
 
 function BlockQuote({ children }: BlockQuoteProps) {
   return (
-    <blockquote style={{ borderLeft: '4px solid #ccc', paddingLeft: '1em', color: '#666' }}>
+    <blockquote
+      className="border-l-4 border-gray-300 pl-4 text-white-2 text-xl italic font-serif"
+    >
       {children}
     </blockquote>
   )
-};
+}
 
 export default BlockQuote;

--- a/apps/web/src/contents/posts/hugo-s-go-to-stack-for-building-maintainable-software.md
+++ b/apps/web/src/contents/posts/hugo-s-go-to-stack-for-building-maintainable-software.md
@@ -114,9 +114,9 @@ As a result, it's essential to strike a balance between maintaining clean code a
 
 > Copy/paste is better than the wrong abstraction [^2].
 >
-> [Lee Robinson (leerob)](https://leerob.com/), VP of Product [@vercel](https://vercel.com/home)
+> [Lee Robinson (leerob)](https://leerob.com/), VP of Product [@vercel](https://vercel.com/home).
 
-> the wrong duplication is better than the wrong abstraction
+> The wrong duplication is better than the wrong abstraction.
 
 [^1]: [Why "he" does not write React.FC on each function?](https://stackoverflow.com/questions/71189879/why-he-does-not-write-react-fc-on-each-function)
 [^2]: [Lee Robinson - Stack](https://leerob.com/n/stack)


### PR DESCRIPTION
This pull request includes updates to the `BlockQuote` component's styling and minor text corrections in a markdown file. 

Styling updates:

* [`apps/web/src/components/markdown/block-quote.tsx`](diffhunk://#diff-19c52cdb9dd02725162565f81d87c2c7d295fc87a82e83ff20bf94b6405253d4L9-R15): Updated the `BlockQuote` component to use Tailwind CSS classes for styling, replacing the inline styles.

Text corrections:

* [`apps/web/src/contents/posts/hugo-s-go-to-stack-for-building-maintainable-software.md`](diffhunk://#diff-4828e8126d8d2debd24c98d35ae7109590bc26a6016cfb943ca241dd84c8fa75L117-R119): Corrected punctuation and capitalization in the quotes and references.