### PR TITLE
refactor(portfolio): rename type for search parameters to improve clarity (#702)

### DIFF
--- a/apps/web/src/app/portfolio/page.tsx
+++ b/apps/web/src/app/portfolio/page.tsx
@@ -17,9 +17,11 @@ export const metadata = {
   description: "Read my thoughts on software development, design, and more.",
 };
 
-type tParams = Promise<{ tag?: string; page?: string }>;
+type PortfolioQueryParams = Promise<{ tag?: string; page?: string }>;
 
-export default async function Portfolio({ searchParams }: { searchParams: tParams }) {
+export default async function Portfolio(
+  { searchParams }: { searchParams: PortfolioQueryParams }
+) {
   const { tag = "All", page = "1" } = await searchParams;
 
   const allPortfolioPosts = await getPortfolioPosts();


### PR DESCRIPTION
This pull request includes a small change to the `apps/web/src/app/portfolio/page.tsx` file. The change refactors the type definition for query parameters to improve code readability.

* Refactored the type definition for query parameters from `tParams` to `PortfolioQueryParams` to improve code readability.