### PR TITLE
refactor(web): add home metadata configuration and update layout to use it (#971)

### DIFF
--- a/apps/web/src/app/(home)/layout.tsx
+++ b/apps/web/src/app/(home)/layout.tsx
@@ -14,55 +14,19 @@ import type { JsonLdHtml } from "@/types/json-ld";
 import "@/app/globals.css";
 
 const {
-  title,
-  description,
-  author,
-  keywords,
   googleAnalyticId,
   googleTagManagerId,
-  openGraph,
   about,
   avatar,
   status,
   navigationLinks,
   jsonLdPerson,
+  homeMetaData
 } = config;
 
 const { firstName, lastName, middleName, preferredName } = about;
 
-export const metadata: Metadata = {
-  title: title,
-  description: description,
-  authors: [{ name: author }],
-  creator: author,
-  keywords: keywords,
-  openGraph: {
-    url: openGraph.url,
-    type: "website",
-    siteName: openGraph.siteName,
-    title: openGraph.title,
-    description: openGraph.description,
-    images: openGraph.images,
-  },
-  manifest: "/manifest.json",
-  twitter: {
-    card: "summary_large_image",
-    title: title,
-    description: description,
-    images: "https://docs.1chooo.com/images/cover-with-1chooo-com.png",
-  },
-  icons: {
-    icon: "/favicon.ico",
-    shortcut: "/favicon.ico",
-    apple: [
-      {
-        url: "/logo192.png",
-        sizes: "192x192",
-        type: "image/png",
-      },
-    ],
-  },
-};
+export const metadata: Metadata = homeMetaData;
 
 const addJsonLd = (): JsonLdHtml => {
   return {

--- a/apps/web/src/config/index.ts
+++ b/apps/web/src/config/index.ts
@@ -112,6 +112,53 @@ const config: Config = {
     { url: `/rss.xml`, icon: LuRss, name: "RSS Feed" },
     { url: `/cv`, icon: MdAttachment, name: "CV" },
   ],
+  homeMetaData: {
+    metadataBase: new URL("https://www.1chooo.com"),
+    title: "Chun-Ho (Hugo) Lin - 1chooo | Open Source Enthusiast",
+    description: "I'm Chun-Ho (Hugo) Lin, a graduate with a Bachelor's degree from National Central University (NCU) 🐿️, driven by a sincere passion for Software Engineering 💻.",
+    authors: [{ name: "Chun-Ho (Hugo) Lin" }],
+    creator: "Chun-Ho (Hugo) Lin",
+    keywords: [
+      "Hugo ChunHo Lin",
+      "1chooo",
+      "Software Engineering",
+      "Next.js",
+      "React",
+    ],
+    openGraph: {
+      url: "https://www.1chooo.com/",
+      type: "website",
+      siteName: "Chun-Ho (Hugo) Lin - 1chooo | Open Source Enthusiast",
+      title: "Chun-Ho (Hugo) Lin - 1chooo | Open Source Enthusiast",
+      description: "I'm Chun-Ho (Hugo) Lin, a graduate with a Bachelor's degree from National Central University (NCU) 🐿️, driven by a sincere passion for Software Engineering 💻.",
+      images: [
+        {
+          url: "https://docs.1chooo.com/images/cover-with-1chooo-com.png",
+          width: 1200,
+          height: 630,
+          alt: "Chun-Ho (Hugo) Lin - 1chooo Cover Image",
+        },
+      ],
+    },
+    manifest: "/manifest.json",
+    twitter: {
+      card: "summary_large_image",
+      title: "Chun-Ho (Hugo) Lin - 1chooo | Open Source Enthusiast",
+      description: "I'm Chun-Ho (Hugo) Lin, a graduate with a Bachelor's degree from National Central University (NCU) 🐿️, driven by a sincere passion for Software Engineering 💻.",
+      images: "https://docs.1chooo.com/images/cover-with-1chooo-com.png",
+    },
+    icons: {
+      icon: "/favicon.ico",
+      shortcut: "/favicon.ico",
+      apple: [
+        {
+          url: "/logo192.png",
+          sizes: "192x192",
+          type: "image/png",
+        },
+      ],
+    },
+  },
   about: {
     firstName: "Chun-Ho",
     lastName: "Lin",

--- a/apps/web/src/config/index.ts
+++ b/apps/web/src/config/index.ts
@@ -119,7 +119,7 @@ const config: Config = {
     authors: [{ name: "Chun-Ho (Hugo) Lin" }],
     creator: "Chun-Ho (Hugo) Lin",
     keywords: [
-      "Hugo ChunHo Lin",
+      "Chun-Ho (Hugo) Lin",
       "1chooo",
       "Software Engineering",
       "Next.js",

--- a/apps/web/src/config/template.ts
+++ b/apps/web/src/config/template.ts
@@ -112,6 +112,53 @@ const config: Config = {
     { url: `/rss.xml`, icon: LuRss, name: "RSS Feed" },
     { url: `/cv`, icon: MdAttachment, name: "CV" },
   ],
+  homeMetaData: {
+    metadataBase: new URL("https://www.1chooo.com"),
+    title: "Chun-Ho (Hugo) Lin - 1chooo | Open Source Enthusiast",
+    description: "I'm Chun-Ho (Hugo) Lin, a graduate with a Bachelor's degree from National Central University (NCU) 🐿️, driven by a sincere passion for Software Engineering 💻.",
+    authors: [{ name: "Chun-Ho (Hugo) Lin" }],
+    creator: "Chun-Ho (Hugo) Lin",
+    keywords: [
+      "Hugo ChunHo Lin",
+      "1chooo",
+      "Software Engineering",
+      "Next.js",
+      "React",
+    ],
+    openGraph: {
+      url: "https://www.1chooo.com/",
+      type: "website",
+      siteName: "Chun-Ho (Hugo) Lin - 1chooo | Open Source Enthusiast",
+      title: "Chun-Ho (Hugo) Lin - 1chooo | Open Source Enthusiast",
+      description: "I'm Chun-Ho (Hugo) Lin, a graduate with a Bachelor's degree from National Central University (NCU) 🐿️, driven by a sincere passion for Software Engineering 💻.",
+      images: [
+        {
+          url: "https://docs.1chooo.com/images/cover-with-1chooo-com.png",
+          width: 1200,
+          height: 630,
+          alt: "Chun-Ho (Hugo) Lin - 1chooo Cover Image",
+        },
+      ],
+    },
+    manifest: "/manifest.json",
+    twitter: {
+      card: "summary_large_image",
+      title: "Chun-Ho (Hugo) Lin - 1chooo | Open Source Enthusiast",
+      description: "I'm Chun-Ho (Hugo) Lin, a graduate with a Bachelor's degree from National Central University (NCU) 🐿️, driven by a sincere passion for Software Engineering 💻.",
+      images: "https://docs.1chooo.com/images/cover-with-1chooo-com.png",
+    },
+    icons: {
+      icon: "/favicon.ico",
+      shortcut: "/favicon.ico",
+      apple: [
+        {
+          url: "/logo192.png",
+          sizes: "192x192",
+          type: "image/png",
+        },
+      ],
+    },
+  },
   about: {
     firstName: "Chun-Ho",
     lastName: "Lin",

--- a/apps/web/src/config/template.ts
+++ b/apps/web/src/config/template.ts
@@ -119,7 +119,7 @@ const config: Config = {
     authors: [{ name: "Chun-Ho (Hugo) Lin" }],
     creator: "Chun-Ho (Hugo) Lin",
     keywords: [
-      "Hugo ChunHo Lin",
+      "Chun-Ho (Hugo) Lin",
       "1chooo",
       "Software Engineering",
       "Next.js",

--- a/apps/web/src/types/config.d.ts
+++ b/apps/web/src/types/config.d.ts
@@ -6,6 +6,7 @@ import type { GiscusProps } from "@giscus/react";
 import type { IconType as ReactIconType } from "react-icons";
 import type { Icon as OcticonsType } from "@primer/octicons-react";
 import type { Person } from "@/types/json-ld";
+import type { Metadata } from "next";
 
 export type VCardIconType = ReactIconType | OcticonsType;
 
@@ -34,6 +35,7 @@ export type Config = {
   navigationLinks: NavigationLink[];
   contacts: Contact[];
   socialLinks: SocialLink[];
+  homeMetaData: Metadata;
   about: About;
   resume: Resume;
   jsonLdPerson: Person;


### PR DESCRIPTION
This pull request includes changes to centralize and simplify the metadata configuration for the home page by consolidating it into a single object within the `config` file. This reduces redundancy and makes the code easier to maintain.

### Metadata Configuration Simplification:

* [`apps/web/src/app/(home)/layout.tsx`](diffhunk://#diff-2015adf13f6fbb10441e5daec9d38c1db1d0bac8fcd938eedb70e563571b0c75L17-R29): Removed individual metadata properties and replaced them with a single `homeMetaData` object from the `config` file.
* [`apps/web/src/config/index.ts`](diffhunk://#diff-3e59e73ab22872470788ca55388dba6cf3c1cb11793b466bb6a15365276701b0R115-R161): Added a new `homeMetaData` object containing all metadata properties, including `title`, `description`, `authors`, `openGraph`, `manifest`, `twitter`, and `icons`.
* [`apps/web/src/config/template.ts`](diffhunk://#diff-3e59e73ab22872470788ca55388dba6cf3c1cb11793b466bb6a15365276701b0R115-R161): Added a new `homeMetaData` object with the same metadata properties as in `index.ts` to ensure consistency across different configurations.