### PR TITLE
style(web): justify social list center in mobile and simplify styling for consistency (#1016)

### DIFF
--- a/apps/web/src/components/layout/side-bar/social-list.tsx
+++ b/apps/web/src/components/layout/side-bar/social-list.tsx
@@ -7,7 +7,7 @@ interface SocialListProps {
 
 function SocialList({ socialLinks }: SocialListProps) {
   return (
-    <ul className="flex justify-start items-center gap-[15px] pb-1 pl-[7px] xl:justify-center md:justify-center">
+    <ul className="flex items-center gap-4 pb-1 pl-2 justify-center">
       {socialLinks.map(({ url, icon: Icon, name }) => (
         <li
           key={name}


### PR DESCRIPTION
This pull request simplifies the styling of the `SocialList` component in the `side-bar` layout by updating the class names applied to the `<ul>` element.

Styling updates:

* [`apps/web/src/components/layout/side-bar/social-list.tsx`](diffhunk://#diff-da886cc7ad1a50e722d6de8bd4e223fbaad877f486995cf30eece8cc9430dbc9L10-R10): Adjusted the class names for the `<ul>` element to use more consistent spacing (`gap-4` instead of `gap-[15px]`) and simplified padding (`pl-2` instead of `pl-[7px]`). Additionally, the `justify-center` class replaces specific responsive `justify-start` and `xl:justify-center` classes for a more uniform layout.