### PR TITLE
Bump pnpm to 10.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "turbo": "^2.5.1",
     "typescript": "5.8.3"
   },
-  "packageManager": "pnpm@10.8.0+sha256.29bf2c5ceaea7991ee82eec15fe7162e0fad816d0c4a6b35a16c01d39274bf69",
+  "packageManager": "pnpm@10.10.0+sha256.f657bc37aa5e08da2ecff3877fe3bbb4b13703ba",
   "engines": {
     "node": ">=20"
   }


### PR DESCRIPTION
Updated package manager to use pnpm 10.10 instead of 10.8