### PR TITLE
feat(web): add pop-over to ResumeCard for detailed info display (#1054)

### DIFF
--- a/apps/web/src/components/resume/resume-card.tsx
+++ b/apps/web/src/components/resume/resume-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import Image from "next/image";
 import { BriefcaseIcon } from "lucide-react";
 import { getIcon } from "@/components/icons";
@@ -14,49 +15,162 @@ interface ResumeCardProps {
 
 export default function ResumeCard({ resumeCard }: ResumeCardProps) {
   const { institution, institutionImage, title, tags } = resumeCard;
+  const [activeResumeCard, setActiveResumeCard] =
+    useState<ResumeCardType | null>(null);
+
+  const openModal = (resumeCard: ResumeCardType) => {
+    setActiveResumeCard(resumeCard);
+  };
+
+  const closeModal = () => {
+    setActiveResumeCard(null);
+  };
+
+  useEffect(() => {
+    const handleEscKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeModal();
+      }
+    };
+
+    if (activeResumeCard) {
+      document.addEventListener("keydown", handleEscKey);
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleEscKey);
+    };
+  }, [activeResumeCard]);
 
   return (
-    <section className="skill">
-      <div className="skills-list resume-card">
-        <div className="flex flex-row items-center gap-4 p-6 pb-4">
-          <div className="h-10 w-10 flex-shrink-0 overflow-hidden rounded-md">
-            <Image
-              src={institutionImage || "/favicon.ico"}
-              alt={institution}
-              className="h-full w-full object-cover"
-              onError={(e) => {
-                e.currentTarget.src = "/favicon.ico?height=40&width=40";
-                e.currentTarget.onerror = null;
-              }}
-              width={40}
-              height={40}
-            />
-          </div>
-          <div className="min-w-0 flex-1 space-y-1">
-            <div className="font-semibold text-white-1 truncate">
-              {institution}
+    <>
+      <section
+        className="skill hover:scale-105 duration-300"
+        onClick={() => openModal(resumeCard)}
+      >
+        <div className="skills-list resume-card">
+          <div className="flex flex-row items-center gap-4 p-6 pb-4 cursor-pointer transition-colors rounded-t-md">
+            <div className="h-10 w-10 flex-shrink-0 overflow-hidden rounded-md">
+              <Image
+                src={institutionImage || "/favicon.ico"}
+                alt={institution}
+                className="h-full w-full object-cover"
+                onError={(e) => {
+                  e.currentTarget.src = "/favicon.ico?height=40&width=40";
+                  e.currentTarget.onerror = null;
+                }}
+                width={40}
+                height={40}
+              />
             </div>
-            <div className="text-sm text-light-gray truncate">{title}</div>
+            <div className="min-w-0 flex-1 space-y-1">
+              <div className="font-semibold text-white-1 truncate">
+                {institution}
+              </div>
+              <div className="text-sm text-light-gray truncate">{title}</div>
+            </div>
           </div>
-        </div>
 
-        <div className="px-6 pb-2">
-          <div className="mb-4 flex flex-wrap gap-2">
-            {tags.map((tag, index) => {
-              const TagIcon = getIcon(tag.icon) || BriefcaseIcon;
-              return (
-                <span
-                  key={`${tag.key}-${index}`}
-                  className="inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium text-orange-yellow-crayola border-gray-700"
-                >
-                  <TagIcon className="h-3 w-3" />
-                  {tag.value}
-                </span>
-              );
-            })}
+          <div className="px-6 pb-2 cursor-pointer transition-colors rounded-b-md">
+            <div className="mb-4 flex flex-wrap gap-2">
+              {tags.map((tag, index) => {
+                const TagIcon = getIcon(tag.icon) || BriefcaseIcon;
+                return (
+                  <span
+                    key={`${tag.key}-${index}`}
+                    className="inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium text-orange-yellow-crayola border-gray-700"
+                  >
+                    <TagIcon className="h-3 w-3" />
+                    {tag.value}
+                  </span>
+                );
+              })}
+            </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
+
+      {/* Modal */}
+      {activeResumeCard && (
+        <div className="modal-container active" aria-modal="true" role="dialog">
+          <div
+            className={`overlay ${activeResumeCard ? "active" : ""}`}
+            onClick={closeModal}
+          ></div>
+          <section className="testimonials-modal">
+            <button
+              className="modal-close-btn"
+              onClick={closeModal}
+              aria-label="Close modal"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <line x1="18" y1="6" x2="6" y2="18"></line>
+                <line x1="6" y1="6" x2="18" y2="18"></line>
+              </svg>
+            </button>
+
+            <div className="modal-img-wrapper">
+              <figure className="modal-avatar-box">
+                <Image
+                  src={activeResumeCard.institutionImage || "/favicon.ico"}
+                  alt={activeResumeCard.institution}
+                  width={80}
+                  height={80}
+                  className="modal-avatar"
+                  onError={(e) => {
+                    e.currentTarget.src = "/favicon.ico?height=80&width=80";
+                    e.currentTarget.onerror = null;
+                  }}
+                />
+              </figure>
+            </div>
+
+            <div className="modal-content">
+              <h3 className="modal-title font-semibold text-white-1 text-2xl">
+                {activeResumeCard.institution}
+              </h3>
+              <h5 className="text-lg text-light-gray mb-4">
+                {activeResumeCard.title}
+              </h5>
+
+              <div className="mb-6">
+                <div className="flex flex-wrap gap-2">
+                  {activeResumeCard.tags.map((tag, index) => {
+                    const TagIcon = getIcon(tag.icon) || BriefcaseIcon;
+                    return (
+                      <span
+                        key={`modal-${tag.key}-${index}`}
+                        className="inline-flex items-center gap-1 rounded-full border px-3 py-1 text-sm font-medium text-orange-yellow-crayola border-gray-700 bg-gray-800/30"
+                      >
+                        <TagIcon className="h-4 w-4" />
+                        {tag.value}
+                      </span>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <div className="text-light-gray">
+                  {activeResumeCard.details.map((item, index) => (
+                    <li key={index}>{item}</li>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      )}
+    </>
   );
 }

--- a/apps/web/src/components/resume/resume-card.tsx
+++ b/apps/web/src/components/resume/resume-card.tsx
@@ -161,11 +161,11 @@ export default function ResumeCard({ resumeCard }: ResumeCardProps) {
               </div>
 
               <div className="space-y-4">
-                <div className="text-light-gray">
+                <ul className="text-light-gray list-disc pl-5">
                   {activeResumeCard.details.map((item, index) => (
                     <li key={index}>{item}</li>
                   ))}
-                </div>
+                </ul>
               </div>
             </div>
           </section>

--- a/apps/web/src/styles/resume-card.css
+++ b/apps/web/src/styles/resume-card.css
@@ -16,3 +16,281 @@
     border-radius: inherit;
     z-index: -1;
 }
+
+/**
+* #testimonials 
+*/
+
+.testimonials {
+    margin-bottom: 30px;
+}
+
+.testimonials-title {
+    margin-bottom: 20px;
+}
+
+.testimonials-list {
+    display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
+    gap: 15px;
+    margin: 0 -15px;
+    padding: 25px 15px;
+    padding-bottom: 35px;
+    overflow-x: auto;
+    scroll-behavior: smooth;
+    overscroll-behavior-inline: contain;
+    scroll-snap-type: inline mandatory;
+}
+
+.clients p {
+    margin-bottom: 15px;
+    color: var(--light-gray);
+    font-size: var(--fs-6);
+    font-weight: var(--fw-300);
+    line-height: 1.6;
+}
+
+.testimonials-item {
+    min-width: 100%;
+    scroll-snap-align: center;
+}
+
+.testimonials-avatar-box {
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform: translate(15px, -25px);
+    background: var(--bg-gradient-onyx);
+    border-radius: 14px;
+    box-shadow: var(--shadow-1);
+}
+
+.testimonials-item-title {
+    margin-bottom: 7px;
+}
+
+.testimonials-text {
+    color: var(--light-gray);
+    font-size: var(--fs-6);
+    font-weight: var(--fw-300);
+    line-height: 1.6;
+    display: -webkit-box;
+    line-clamp: 4;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+/**
+  * #testimonials-modal
+  */
+
+.modal-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    z-index: 20;
+    pointer-events: none;
+    visibility: hidden;
+}
+
+.modal-container::-webkit-scrollbar {
+    display: none;
+}
+
+.modal-container.active {
+    pointer-events: all;
+    visibility: visible;
+}
+
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    background: hsl(0, 0%, 5%);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    z-index: 1;
+    transition: var(--transition-1);
+}
+
+.overlay.active {
+    opacity: 0.8;
+    visibility: visible;
+    pointer-events: all;
+}
+
+.testimonials-modal {
+    background: var(--eerie-black-2);
+    position: relative;
+    padding: 15px;
+    margin: 15px 12px;
+    border: 1px solid var(--jet);
+    border-radius: 14px;
+    box-shadow: var(--shadow-5);
+    transform: scale(1.2);
+    opacity: 0;
+    transition: var(--transition-1);
+    z-index: 2;
+}
+
+.modal-container.active .testimonials-modal {
+    transform: scale(1);
+    opacity: 1;
+}
+
+.modal-close-btn {
+    position: absolute;
+    top: 15px;
+    right: 15px;
+    background: var(--onyx);
+    border-radius: 8px;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: var(--white-2);
+    font-size: 18px;
+    opacity: 0.7;
+}
+
+.modal-close-btn:hover,
+.modal-close-btn:focus {
+    opacity: 1;
+}
+
+.modal-avatar-box {
+    background: var(--bg-gradient-onyx);
+    width: max-content;
+    border-radius: 14px;
+    margin-bottom: 15px;
+    box-shadow: var(--shadow-2);
+}
+
+.modal-img-wrapper>img {
+    display: none;
+}
+
+.modal-title {
+    margin-bottom: 4px;
+}
+
+.modal-content time {
+    font-size: var(--fs-6);
+    color: var(--light-gray-70);
+    font-weight: var(--fw-300);
+    margin-bottom: 10px;
+}
+
+.modal-content p {
+    color: var(--light-gray);
+    font-size: var(--fs-6);
+    font-weight: var(--fw-300);
+    line-height: 1.6;
+}
+
+@media (min-width: 580px) {
+    /* testimonials */
+
+    .testimonials-title {
+        margin-bottom: 25px;
+    }
+
+    .testimonials-list {
+        gap: 30px;
+        margin: 0 -30px;
+        padding: 30px;
+        padding-bottom: 35px;
+    }
+
+    .content-card {
+        padding: 30px;
+        padding-top: 25px;
+    }
+
+    .testimonials-avatar-box {
+        transform: translate(30px, -30px);
+        border-radius: 20px;
+    }
+
+    .testimonials-avatar-box img {
+        width: 80px;
+    }
+
+    .testimonials-item-title {
+        margin-bottom: 10px;
+        margin-left: 95px;
+    }
+
+    .testimonials-text {
+        line-clamp: 2;
+        -webkit-line-clamp: 2;
+    }
+
+    /* testimonials modal */
+
+    .modal-container {
+        padding: 20px;
+    }
+
+    .testimonials-modal {
+        display: flex;
+        justify-content: flex-start;
+        align-items: stretch;
+        gap: 25px;
+        padding: 30px;
+        border-radius: 20px;
+    }
+
+    .modal-img-wrapper {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .modal-avatar-box {
+        border-radius: 18px;
+        margin-bottom: 0;
+    }
+
+    .modal-avatar-box img {
+        width: 65px;
+    }
+
+    .modal-img-wrapper>img {
+        display: block;
+        flex-grow: 1;
+        width: 35px;
+    }
+}
+
+@media (min-width: 768px) {
+    /* testimonials modal */
+
+    .testimonials-modal {
+        gap: 35px;
+        max-width: 680px;
+    }
+
+    .modal-avatar-box img {
+        width: 80px;
+    }
+}
+
+@media (min-width: 1024px) {
+    .testimonials-item {
+        min-width: calc(50% - 15px);
+    }
+}


### PR DESCRIPTION
This pull request introduces a modal feature to the `ResumeCard` component, allowing users to view detailed information about a resume card in a modal dialog. It also includes corresponding styling updates to support the modal and enhance the user interface.

### Functional Enhancements:
* Added state management (`useState`) and event handling (`useEffect`) to manage the modal's visibility and close it when the "Escape" key is pressed. (`apps/web/src/components/resume/resume-card.tsx`) [[1]](diffhunk://#diff-0424a516c336a147f50d6b0f8a0be434cf3f4820597bfb6a895daec94df0b58fR3) [[2]](diffhunk://#diff-0424a516c336a147f50d6b0f8a0be434cf3f4820597bfb6a895daec94df0b58fR18-R52)
* Implemented a modal dialog that displays detailed information about the selected resume card, including institution, title, tags, and additional details. (`apps/web/src/components/resume/resume-card.tsx`)

### UI/UX Improvements:
* Enhanced the `ResumeCard` component with hover effects and transitions for better interactivity. (`apps/web/src/components/resume/resume-card.tsx`)
* Added extensive CSS styling for the modal, including animations, responsiveness, and accessibility features such as an overlay and close button. (`apps/web/src/styles/resume-card.css`)