### PR TITLE
feat(web): make color theme more customizable

### DIFF
--- a/apps/docs/src/content/stack.mdx
+++ b/apps/docs/src/content/stack.mdx
@@ -44,7 +44,7 @@ Copy/paste is better than the wrong abstraction [^2].
 When designing hover effects for anchor tags, we use the following classes to style the anchor tags:
 
 ```tsx
-className="text-orange-yellow-crayola underline hover:text-opacity-70 hover:decoration-light-gray-70"
+className="text-primary underline hover:text-opacity-70 hover:decoration-light-gray-70"
 ```
 
 ## Footnotes

--- a/apps/docs/src/content/wiki.mdx
+++ b/apps/docs/src/content/wiki.mdx
@@ -840,7 +840,7 @@ export default function ResumeCard({ timeLine, sectionType }: ResumeCardProps) {
 
         <div className="px-6 pb-2">
           <div className="mb-4 flex flex-wrap gap-2">
-            <span className="inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium text-orange-yellow-crayola border-gray-700">
+            <span className="inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium text-primary border-gray-700">
               {sectionType === "education" ? (
                 <School className="h-3 w-3" />
               ) : sectionType === "experience" ? (
@@ -848,11 +848,11 @@ export default function ResumeCard({ timeLine, sectionType }: ResumeCardProps) {
               ) : null}
               {employmentType}
             </span>
-            <span className="inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium text-orange-yellow-crayola border-gray-700">
+            <span className="inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium text-primary border-gray-700">
               <MapPin className="h-3 w-3" />
               {location}
             </span>
-            <span className="inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium text-orange-yellow-crayola border-gray-700">
+            <span className="inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium text-primary border-gray-700">
               <CalendarIcon className="h-3 w-3" />
               {timePeriod}
             </span>

--- a/apps/web/src/app/(exp)/remark/layout.tsx
+++ b/apps/web/src/app/(exp)/remark/layout.tsx
@@ -42,7 +42,7 @@ function RemarkLayout({ children }: { readonly children: React.ReactNode }) {
   return (
     <html lang="en" className={roboto.className}>
       <body>
-        <ProgressBar className="fixed top-0 h-1 bg-yellow-500">
+        <ProgressBar className="fixed top-0 h-1 bg-progress-bar">
           <Hello />
           <main>
             <SideBar

--- a/apps/web/src/app/(home)/layout.tsx
+++ b/apps/web/src/app/(home)/layout.tsx
@@ -42,7 +42,7 @@ function HomeLayout({ children }: { readonly children: React.ReactNode }) {
   return (
     <html lang="en" className={roboto.className}>
       <body>
-        <ProgressBar className="fixed top-0 h-1 bg-yellow-500">
+        <ProgressBar className="fixed top-0 h-1 bg-progress-bar">
           <Hello />
           <main>
             <SideBar

--- a/apps/web/src/app/(home)/not-found.tsx
+++ b/apps/web/src/app/(home)/not-found.tsx
@@ -35,7 +35,7 @@ function NotFound() {
             <div className="flex items-center justify-center">
               <Link
                 href="/"
-                className="flex items-center border-none px-4 py-2 mx-1 cursor-pointer text-base bg-border-gradient-onyx hover:scale-105 active:scale-95 rounded-xl shadow-lg hover:bg-orange-yellow-crayola-dark text-white-2 font-bold"
+                className="flex items-center border-none px-4 py-2 mx-1 cursor-pointer text-base bg-border-gradient-onyx hover:scale-105 active:scale-95 rounded-xl shadow-lg hover:bg-primary-dark text-white-2 font-bold"
               >
                 <Home className="mr-2 h-4 w-4" />
                 <span>Return Home</span>
@@ -44,7 +44,7 @@ function NotFound() {
             <div className="flex items-center justify-center">
               <Link
                 href="javascript:history.back()"
-                className="flex items-center border-none px-4 py-2 mx-1 cursor-pointer text-base bg-border-gradient-onyx hover:scale-105 active:scale-95 rounded-xl shadow-lg hover:bg-orange-yellow-crayola-dark text-orange-yellow-crayola font-bold"
+                className="flex items-center border-none px-4 py-2 mx-1 cursor-pointer text-base bg-border-gradient-onyx hover:scale-105 active:scale-95 rounded-xl shadow-lg hover:bg-primary-dark text-primary font-bold"
               >
                 <ArrowLeft className="mr-2 h-4 w-4" />
                 <span>Go Back</span>

--- a/apps/web/src/app/(home)/post/[slug]/page.tsx
+++ b/apps/web/src/app/(home)/post/[slug]/page.tsx
@@ -126,7 +126,7 @@ export default async function Post(props: { params: tParams }) {
       <article>
         <section className="blog-text">
           <header>
-            <h1 className="relative pb-[7px] mb-[30px] font-semibold text-3xl text-light-gray after:content-[''] after:absolute after:bottom-0 after:left-0 after:w-[30px] after:h-[3px] after:rounded-sm  after:bg-text-gradient-yellow sm:pb-[15px] sm:after:w-[40px] sm:after:h-[5px] md:pb-[20px]">
+            <h1 className="relative pb-[7px] mb-[30px] font-semibold text-3xl text-light-gray after:content-[''] after:absolute after:bottom-0 after:left-0 after:w-[30px] after:h-[3px] after:rounded-sm  after:bg-gradient-primary sm:pb-[15px] sm:after:w-[40px] sm:after:h-[5px] md:pb-[20px]">
               {"Hugo's Blog"}
             </h1>
           </header>
@@ -147,7 +147,7 @@ export default async function Post(props: { params: tParams }) {
                 href={`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="hover:text-orange-yellow-crayola transition-colors"
+                className="hover:text-primary transition-colors"
                 aria-label="Share on Facebook"
               >
                 <LuFacebook className="w-5 h-5" />
@@ -156,7 +156,7 @@ export default async function Post(props: { params: tParams }) {
                 href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent(shareText)}`}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="hover:text-orange-yellow-crayola transition-colors"
+                className="hover:text-primary transition-colors"
                 aria-label="Share on Twitter"
               >
                 <LuTwitter className="w-5 h-5" />

--- a/apps/web/src/app/(home)/post/page.tsx
+++ b/apps/web/src/app/(home)/post/page.tsx
@@ -94,7 +94,7 @@ async function BlogPosts({ searchParams }: { searchParams: BlogQueryParams }) {
                     )}
                   </time>
                 </div>
-                <h3 className="text-2xl text-white-2 font-semibold leading-[1.3] transition-all hover:text-orange-yellow-crayola">
+                <h3 className="text-2xl text-white-2 font-semibold leading-[1.3] transition-all hover:text-primary">
                   <Balancer>
                     <MarkdownRenderer content={post.metadata.title} />
                   </Balancer>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -39,6 +39,18 @@
   --text-gradient-yellow: linear-gradient(to right,
       hsl(45, 100%, 72%),
       hsl(35, 100%, 68%));
+  --gradient-primary: linear-gradient(to right,
+      var(--color-primary),
+      var(--color-primary-gradient-dark));
+
+  --gradient-primary-bottom-right: linear-gradient(to bottom right,
+      var(--color-primary) 0%,
+      var(--color-primary-gradient-dark-2) 50%);
+
+  --gradient-primary-bottom-right-2: linear-gradient(135deg,
+      var(--color-primary-2) 0%,
+      var(--color-primary-gradient-dark-2) 60%),
+    hsl(240, 2%, 13%);
 
   /* solid */
 
@@ -50,10 +62,18 @@
   --white-1: hsl(0, 0%, 100%);
   --white-2: hsl(0, 0%, 98%);
   --orange-yellow-crayola: hsl(45, 100%, 72%);
+  --orange-yellow-crayola-2: hsla(45, 100%, 72%, 0.25);
+  --orange-yellow-crayola-dark: hsl(45, 100%, 10%);
   --vegas-gold: hsl(45, 54%, 58%);
   --light-gray: hsl(0, 0%, 84%);
   --light-gray-70: hsla(0, 0%, 84%, 0.7);
   --bittersweet-shimmer: hsl(0, 43%, 51%);
+
+  --color-primary: var(--orange-yellow-crayola);
+  --color-primary-2: var(--orange-yellow-crayola-2);
+  --color-primary-dark: var(--orange-yellow-crayola-dark);
+  --color-primary-gradient-dark: hsl(35, 100%, 68%);
+  --color-primary-gradient-dark-2: hsla(35, 100%, 68%, 0);
 
   /**
   * typography
@@ -137,12 +157,12 @@ textarea {
 }
 
 ::selection {
-  background: var(--orange-yellow-crayola);
+  background: var(--color-primary);
   color: var(--smoky-black);
 }
 
 :focus {
-  outline-color: var(--orange-yellow-crayola);
+  outline-color: var(--color-primary);
 }
 
 body {
@@ -325,7 +345,7 @@ article {
 }
 
 .has-scrollbar::-webkit-scrollbar-thumb {
-  background: var(--orange-yellow-crayola);
+  background: var(--color-primary);
   border-radius: 5px;
 }
 
@@ -377,7 +397,7 @@ main {
   left: 0;
   width: 30px;
   height: 3px;
-  background: var(--text-gradient-yellow);
+  background: var(--gradient-primary);
   border-radius: 3px;
 }
 
@@ -510,18 +530,18 @@ main {
   left: -33px;
   height: 6px;
   width: 6px;
-  background: var(--text-gradient-yellow);
+  background: var(--gradient-primary);
   border-radius: 50%;
   box-shadow: 0 0 0 4px var(--jet);
 }
 
 .content-highlight-yellow {
-  color: var(--orange-yellow-crayola);
+  color: var(--color-primary);
   display: inline;
 }
 
 .code-highlight-yellow {
-  color: var(--orange-yellow-crayola);
+  color: var(--color-primary);
   display: inline;
 }
 
@@ -634,7 +654,7 @@ main {
 }
 
 .project-item>a:hover .project-title {
-  color: var(--orange-yellow-crayola);
+  color: var(--color-primary);
   font-weight: bold;
 }
 
@@ -681,7 +701,7 @@ main {
   --scale: 0.8;
 
   background: var(--jet);
-  color: var(--orange-yellow-crayola);
+  color: var(--color-primary);
   position: absolute;
   top: 50%;
   left: 50%;
@@ -870,7 +890,7 @@ main {
 }
 
 .form-input:focus {
-  border-color: var(--orange-yellow-crayola);
+  border-color: var(--color-primary);
 }
 
 textarea.form-input {
@@ -893,7 +913,7 @@ textarea.form-input::-webkit-resizer {
   position: relative;
   width: 100%;
   background: var(--border-gradient-onyx);
-  color: var(--orange-yellow-crayola);
+  color: var(--color-primary);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -918,11 +938,11 @@ textarea.form-input::-webkit-resizer {
 }
 
 .form-btn:hover {
-  background: var(--bg-gradient-yellow-1);
+  background: var(--gradient-primary-bottom-right);
 }
 
 .form-btn:hover::before {
-  background: var(--bg-gradient-yellow-2);
+  background: var(--gradient-primary-bottom-right-2);
 }
 
 .form-btn:disabled {
@@ -1197,7 +1217,7 @@ textarea.form-input::-webkit-resizer {
   }
 
   .filter-item button.active {
-    color: var(--orange-yellow-crayola);
+    color: var(--color-primary);
   }
 
   .filter-item a:hover {
@@ -1205,7 +1225,7 @@ textarea.form-input::-webkit-resizer {
   }
 
   .filter-item a.active {
-    color: var(--orange-yellow-crayola);
+    color: var(--color-primary);
   }
 
   /* portfolio and blog grid */

--- a/apps/web/src/components/about/coding-stats.tsx
+++ b/apps/web/src/components/about/coding-stats.tsx
@@ -8,6 +8,7 @@ import { BlurFade } from "@/components/magicui/blur-fade";
 import Globe from "@/components/about/globe";
 import { Marquee } from "@/components/about/marquee";
 import { getIcon, ICON_NAMES } from "@/components/icons";
+import config from "@/config";
 
 import "@/styles/about/coding-stats.css";
 
@@ -27,9 +28,9 @@ interface CodingStatsProps {
 }
 
 function CodingStats({ techStacks, githubUsername }: CodingStatsProps) {
-  const yellowTheme: ThemeInput = {
-    light: ["#EBEBEB", "#FFDA6B"],
-    dark: ["#383838", "#FFDA6B"],
+  const theme: ThemeInput = {
+    light: ["#EBEBEB", config.primaryColor],
+    dark: ["#383838", config.primaryColor],
   };
 
   const Map = getIcon(ICON_NAMES.MAP_PIN_LU);
@@ -51,7 +52,7 @@ function CodingStats({ techStacks, githubUsername }: CodingStatsProps) {
                   return (
                     <Icon
                       key={stack.name}
-                      className="size-10 text-white-2 hover:scale-110 hover:text-orange-yellow-crayola"
+                      className="size-10 text-white-2 hover:scale-110 hover:text-primary"
                     />
                   );
                 })}
@@ -62,7 +63,7 @@ function CodingStats({ techStacks, githubUsername }: CodingStatsProps) {
                   return (
                     <Icon
                       key={stack.name}
-                      className="size-10 text-white-2 hover:scale-110 hover:text-orange-yellow-crayola"
+                      className="size-10 text-white-2 hover:scale-110 hover:text-primary"
                     />
                   );
                 })}
@@ -75,7 +76,7 @@ function CodingStats({ techStacks, githubUsername }: CodingStatsProps) {
               <div className="flex items-center gap-2 text-white-2 mt-4 ml-4">
                 <Map size={18} />
                 <h2 className="text-sm font-light">
-                  Taipei, Taiwan (UTC +08:00)
+                  {config.globe.heading}
                 </h2>
               </div>
               <Globe />
@@ -94,7 +95,7 @@ function CodingStats({ techStacks, githubUsername }: CodingStatsProps) {
             blockRadius={2}
             fontSize={14}
             style={{ fontWeight: "bold" }}
-            theme={yellowTheme}
+            theme={theme}
           />
         </section>
       </BlurFade>

--- a/apps/web/src/components/about/globe.tsx
+++ b/apps/web/src/components/about/globe.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef } from "react";
 import createGlobe from "cobe";
 import { useSpring } from "react-spring";
+import config from "@/config";
 
 /**
  * @see https://github.com/shuding/cobe/tree/main/website/pages/docs/showcases
@@ -46,9 +47,9 @@ function Globe() {
       mapSamples: 12_000,
       mapBrightness: 2,
       baseColor: [0.8, 0.8, 0.8],
-      markerColor: [1, 0.85, 0.42],
+      markerColor: config.globe.markerColor,
       glowColor: [0.5, 0.5, 0.5],
-      markers: [{ location: [25.105497, 121.597366], size: 0.1 }],
+      markers: [{ location: config.globe.location, size: 0.1 }],
       scale: 1.05,
       onRender: (state) => {
         state.phi = 2.75 + r.get();

--- a/apps/web/src/components/about/latest-articles.tsx
+++ b/apps/web/src/components/about/latest-articles.tsx
@@ -60,7 +60,7 @@ export function LatestArticles({ posts }: Props) {
                 rel="noopener noreferrer"
               >
                 <figure className="latest-post-img">
-                  <div className="absolute latest-post-item-icon-box text-orange-yellow-crayola text-xl bg-jet p-[18px] rounded-xl top-1/2 left-1/2 transition-all duration-250 ease-linear">
+                  <div className="absolute latest-post-item-icon-box text-primary text-xl bg-jet p-[18px] rounded-xl top-1/2 left-1/2 transition-all duration-250 ease-linear">
                     <LuEye />
                   </div>
                   <Image
@@ -74,7 +74,7 @@ export function LatestArticles({ posts }: Props) {
                     loading="eager"
                   />
                 </figure>
-                <h3 className="ml-[10px] text-white-2 text-base font-normal capitalize leading-[1.3] group-hover:text-orange-yellow-crayola group-hover:font-bold">
+                <h3 className="ml-[10px] text-white-2 text-base font-normal capitalize leading-[1.3] group-hover:text-primary group-hover:font-bold">
                   {post.title}
                 </h3>
               </ProgressBarLink>

--- a/apps/web/src/components/about/life-styles.tsx
+++ b/apps/web/src/components/about/life-styles.tsx
@@ -20,7 +20,7 @@ function LifeStyles({ lifestyles }: LifeStylesProps) {
             return (
               <GradientCard key={lifestyle.title || index}>
                 <div className="mb-2.5 sm:mb-0 sm:mt-2 flex justify-center items-center">
-                  <Icon className="text-orange-yellow-crayola" size={24} />
+                  <Icon className="text-primary" size={24} />
                 </div>
 
                 <div className="text-center sm:text-left">

--- a/apps/web/src/components/about/see-more-button.tsx
+++ b/apps/web/src/components/about/see-more-button.tsx
@@ -15,7 +15,7 @@ function SeeMoreButton({ badge, path, icon: Icon }: SeeMoreButtonProps) {
     <div className="flex justify-center">
       <ProgressBarLink href={path}>
         <button
-          className="hover:scale-105 active:scale-95 rounded-xl shadow-lg bg-border-gradient-onyx hover:bg-orange-yellow-crayola-dark z-0 cursor-pointer text-orange-yellow-crayola px-5 py-3 font-bold"
+          className="hover:scale-105 active:scale-95 rounded-xl shadow-lg bg-border-gradient-onyx hover:bg-primary-dark z-0 cursor-pointer text-primary px-5 py-3 font-bold"
           onClick={() =>
             sendGTMEvent({
               event: "buttonClicked",

--- a/apps/web/src/components/icon-box.tsx
+++ b/apps/web/src/components/icon-box.tsx
@@ -11,7 +11,7 @@ function IconBox({ iconName }: IconBoxProps) {
   const Icon = getIcon(iconName) || Swords;
 
   return (
-    <div className="icon-box bg-border-gradient-onyx text-orange-yellow-crayola flex items-center justify-center text-lg shadow-shadow-1 relative rounded-xl w-[40px] h-[40px] md:w-[48px] md:h-[48px] md:text-xl z-1 before:bg-eerie-black-1 before:rounded-xl before:absolute before:content-[''] before:inset-[1px]">
+    <div className="icon-box bg-border-gradient-onyx text-primary flex items-center justify-center text-lg shadow-shadow-1 relative rounded-xl w-[40px] h-[40px] md:w-[48px] md:h-[48px] md:text-xl z-1 before:bg-eerie-black-1 before:rounded-xl before:absolute before:content-[''] before:inset-[1px]">
       <Icon />
     </div>
   );

--- a/apps/web/src/components/layout/side-bar.tsx
+++ b/apps/web/src/components/layout/side-bar.tsx
@@ -92,7 +92,7 @@ function SideBar({
             const ContentElement = link ? (
               <Link
                 href={link}
-                className="block text-white-2 text-sm font-light truncate hover:text-orange-yellow-crayola
+                className="block text-white-2 text-sm font-light truncate hover:text-primary
             transition-colors"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -125,7 +125,7 @@ function SideBar({
             return (
               <li
                 key={icon}
-                className="text-light-gray-70 text-lg hover:scale-110 hover:text-orange-yellow-crayola"
+                className="text-light-gray-70 text-lg hover:scale-110 hover:text-primary"
               >
                 <Link
                   href={url}

--- a/apps/web/src/components/markdown/anchor.tsx
+++ b/apps/web/src/components/markdown/anchor.tsx
@@ -22,7 +22,7 @@ function Anchor({ children, ...props }: AnchorProps) {
 
   return (
     <a
-      className="inline text-orange-yellow-crayola underline hover:text-opacity-70"
+      className="inline text-primary underline hover:text-opacity-70"
       target="_blank"
       rel="noreferrer"
       {...props}

--- a/apps/web/src/components/pagination.tsx
+++ b/apps/web/src/components/pagination.tsx
@@ -22,9 +22,9 @@ function Pagination({
             pathname: basePath,
             query: { tag: selectedTag, page: pageNum.toString() },
           }}
-          className={`flex items-center justify-center border-none w-10 h-10 px-4 py-2 mx-1 cursor-pointer text-base bg-border-gradient-onyx hover:scale-105 active:scale-95 rounded-xl shadow-lg hover:bg-orange-yellow-crayola-dark ${
+          className={`flex items-center justify-center border-none w-10 h-10 px-4 py-2 mx-1 cursor-pointer text-base bg-border-gradient-onyx hover:scale-105 active:scale-95 rounded-xl shadow-lg hover:bg-primary-dark ${
             pageNum === currentPage
-              ? "text-orange-yellow-crayola"
+              ? "text-primary"
               : "text-white-2"
           }`}
           style={{

--- a/apps/web/src/components/resume/resume-card.tsx
+++ b/apps/web/src/components/resume/resume-card.tsx
@@ -78,7 +78,7 @@ export default function ResumeCard({ resumeCard }: ResumeCardProps) {
                 return (
                   <span
                     key={`${tag.key}-${index}`}
-                    className="inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium text-orange-yellow-crayola border-gray-700"
+                    className="inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium text-primary border-gray-700"
                   >
                     <TagIcon className="h-3 w-3" />
                     {tag.value}
@@ -150,7 +150,7 @@ export default function ResumeCard({ resumeCard }: ResumeCardProps) {
                     return (
                       <span
                         key={`modal-${tag.key}-${index}`}
-                        className="inline-flex items-center gap-1 rounded-full border px-3 py-1 text-sm font-medium text-orange-yellow-crayola border-gray-700 bg-gray-800/30"
+                        className="inline-flex items-center gap-1 rounded-full border px-3 py-1 text-sm font-medium text-primary border-gray-700 bg-gray-800/30"
                       >
                         <TagIcon className="h-4 w-4" />
                         {tag.value}

--- a/apps/web/src/config/index.ts
+++ b/apps/web/src/config/index.ts
@@ -90,6 +90,12 @@ const config: Config = {
       icon: ICON_NAMES.ATTACHMENT_MD,
     },
   ],
+  globe: {
+    heading: "Taipei, Taiwan (UTC +08:00)",
+    location: [25.105497, 121.597366],
+    markerColor: [1, 0.85, 0.42],
+  },
+  primaryColor: "#FFDA6B",
   homeMetaData: {
     metadataBase: new URL("https://www.1chooo.com"),
     title: "Chun-Ho (Hugo) Lin - 1chooo | Open Source Enthusiast",

--- a/apps/web/src/contents/posts/how-to-add-linear-gradient-effect-to-text.md
+++ b/apps/web/src/contents/posts/how-to-add-linear-gradient-effect-to-text.md
@@ -50,7 +50,7 @@ However, we encountered a problem when we want to select the text. The selected 
 
 ```css
 ::selection {
-  background: var(--orange-yellow-crayola);
+  background: var(--color-primary);
   color: var(--smoky-black);
 }
 ```
@@ -82,7 +82,7 @@ You can add a transparent text fill color on selection, which allows the `::sele
 ```css
 /* Selection styling */
 ::selection {
-  background: var(--orange-yellow-crayola);
+  background: var(--color-primary);
   color: var(--smoky-black);
 }
 
@@ -102,7 +102,7 @@ You can add a transparent text fill color on selection, which allows the `::sele
 .info-content .name::selection {
   -webkit-text-fill-color: var(--smoky-black); /* Applies black color to text */
   color: var(--smoky-black); /* Fallback for non-WebKit browsers */
-  background: var(--orange-yellow-crayola);
+  background: var(--color-primary);
 }
 ```
 
@@ -128,7 +128,7 @@ Another option is to add a subtle `text-shadow` to simulate the gradient color b
 
 /* Override selection */
 .info-content .name::selection {
-  background: var(--orange-yellow-crayola);
+  background: var(--color-primary);
   -webkit-text-fill-color: var(--smoky-black);
   color: var(--smoky-black);
 }
@@ -142,7 +142,7 @@ I chose the first solution to solve this problem. And below is the segment of th
 + .info-content .name::selection {
 +   -webkit-text-fill-color: var(--smoky-black);
 +   color: var(--smoky-black);
-+   background: var(--orange-yellow-crayola);
++   background: var(--color-primary);
 + }
 ```
 

--- a/apps/web/src/styles/layout/footer.css
+++ b/apps/web/src/styles/layout/footer.css
@@ -18,7 +18,7 @@
 
 .footer-link {
     display: inline;
-    color: var(--orange-yellow-crayola);
+    color: var(--color-primary);
     text-decoration: underline;
 }
 

--- a/apps/web/src/styles/markdown-styles.css
+++ b/apps/web/src/styles/markdown-styles.css
@@ -28,13 +28,13 @@
 }
 
 .markdown mark {
-  color: var(--orange-yellow-crayola);
+  color: var(--color-primary);
   background-color: transparent;
 }
 
 .markdown a {
   display: inline;
-  color: var(--orange-yellow-crayola);
+  color: var(--color-primary);
   text-decoration: underline;
 }
 

--- a/apps/web/src/styles/nav-bar.css
+++ b/apps/web/src/styles/nav-bar.css
@@ -37,7 +37,7 @@
 }
 
 .navbar-link.active {
-    color: var(--orange-yellow-crayola);
+    color: var(--color-primary);
     font-weight: bold;
 }
 

--- a/apps/web/src/styles/side-bar.css
+++ b/apps/web/src/styles/side-bar.css
@@ -42,7 +42,7 @@
     right: -15px;
     border-radius: 0 15px;
     font-size: 13px;
-    color: var(--orange-yellow-crayola);
+    color: var(--color-primary);
     background: var(--border-gradient-onyx);
     padding: 10px;
     box-shadow: var(--shadow-2);
@@ -62,12 +62,12 @@
 
 .info-more-btn:hover,
 .info-more-btn:focus {
-    background: var(--bg-gradient-yellow-1);
+    background: var(--gradient-primary-bottom-right);
 }
 
 .info-more-btn:hover::before,
 .info-more-btn:focus::before {
-    background: var(--bg-gradient-yellow-2);
+    background: var(--gradient-primary-bottom-right-2);
 }
 
 .info-more-btn span {
@@ -137,7 +137,7 @@
 .info-content .name::selection {
     -webkit-text-fill-color: var(--smoky-black);
     color: var(--smoky-black);
-    background: var(--orange-yellow-crayola);
+    background: var(--color-primary);
 }
 
 .info-content .title {

--- a/apps/web/src/styles/skills-bar.css
+++ b/apps/web/src/styles/skills-bar.css
@@ -37,7 +37,7 @@
 }
 
 .skill-progress-fill {
-    background: var(--text-gradient-yellow);
+    background: var(--gradient-primary);
     height: 100%;
     border-radius: inherit;
 }

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -28,6 +28,9 @@ const config: Partial<Config> = {
         "color-3": "hsl(var(--color-3))",
         "color-4": "hsl(var(--color-4))",
         "color-5": "hsl(var(--color-5))",
+        "primary": "hsl(45, 100%, 72%)",
+        "primary-dark": "hsl(45, 100%, 10%)",
+        "progress-bar": "hsl(45, 93%, 47%)",
       },
       backgroundImage: {
         "gradient-onyx":
@@ -42,6 +45,7 @@ const config: Partial<Config> = {
           "linear-gradient(to bottom right, hsl(0, 0%, 25%) 0%, hsla(0, 0%, 25%, 0) 50%)",
         "text-gradient-yellow":
           "linear-gradient(to right, hsl(45, 100%, 72%), hsl(35, 100%, 68%))",
+        "gradient-primary": "var(--gradient-primary)",
       },
       borderRadius: {
         lg: `var(--radius)`,


### PR DESCRIPTION
I wanted to change the primary color for my own usage, so I refactored a bit to make it easier to customize, by replacing color specific variable with primary & primary-dark colors

With this it basically allows you full customization of the color by editing tailwind config, global.css and also config.ts for github calendar & globe

Note that I don't use the css var directly in the tailwind config because it mess up the applied tailwind opacity if you declare it has `"primary" : "var(--color-primary)"` for example.

Here's a [commit](https://github.com/tristanwagner/1chooo.com/commit/bbd51a6e7399e0ec53e019cca8ddf3d7a36448a4) that showcase full color switching with just a few edits

And the results: 
![Screenshot 2025-06-09 at 18 31 58](https://github.com/user-attachments/assets/a9e1a0b1-8b73-48ad-b113-75057ede8e76)

I also added a few configuration to the globe from the config.ts file, that I find useful like heading and location.

I checked that your current render is not affected by this and it seems quite similar to me, but you should double check if you can

If you find it useful feel free to merge it otherwise you can close the PR :)
