### PR TITLE
feat(web): add project pages with remark to enhance speed of loading (#1208)

### DIFF
--- a/apps/web/_posts/project/1chooo-com.md
+++ b/apps/web/_posts/project/1chooo-com.md
@@ -1,0 +1,110 @@
+---
+title: "1chooo.com"
+excerpt: "I'm Chun-Ho (Hugo) Lin, a graduate with a Bachelor's degree from National Central University (NCU) 🐿️, driven by a sincere passion for Software Engineering 💻."
+coverImage: "/images/banner/projects/1chooo-com.webp"
+category: "Web Development"
+date: "2024-01-06"
+startDate: 2024-01-06
+endDate: 2024-12-31
+publishedAt: "2024-12-31"
+author:
+  name: 1chooo
+  avatar: "https://github.com/1chooo.png"
+ogImage:
+  url: "/images/banner/projects/1chooo-com.webp"
+lastModifiedAt: "2025-01-02"
+summary: "👨🏻‍💻 $ ls -al Hugo -- A Turborepo of my personal website and blog built using React and Next.js, and Nextra (V3), fully responsive across all devices"
+tags: 
+  - Next.js
+  - React
+  - Turbo
+  - Portfolio
+  - Blog
+---
+
+👨🏻‍💻 $ ls -al Hugo -- A Turborepo of my personal website and blog built using React and Next.js, and Nextra (V3), fully responsive across all devices
+
+<div align="center">
+  <strong>
+    <a href="https://github.com/1chooo/portfolio">💻 Source Code</a>&nbsp;&nbsp;&bull;&nbsp;
+    <a href="https://1chooo.com">🎥 Demo</a>&nbsp;&nbsp;&bull;&nbsp;
+    <a href="https://docs.1chooo.com">📚 Docs</a>
+  </strong>
+</div>
+
+![1chooo.com](/images/banner/projects/1chooo-com.webp)
+
+## 📍 Abstract
+
+Inspired by the [codewithsadee/vcard-personal-portfolio](https://github.com/codewithsadee/vcard-personal-portfolio), we aim to convert the `HTML/CSS` template into a [React-based](https://react.dev/) project using [Next.js Turborepo](https://turbo.build/).
+
+Our goal is to provide a template where users can build their own portfolio and blog by simply modifying the **configuration and content** without changing the core code. Users will be able to set up their portfolio by updating the config and adding their own posts to the `contents` folder.
+
+We'll also provide comprehensive documentation, including a user guide, code walkthrough, and thorough test coverage to ensure a smooth experience.
+
+## ✨ Features
+
+- 💀 [Skeleton Loading]
+- ⚡️ [Next.js 15 with App Router]
+- ✍🏻 [Markdown Rendering]
+- 🧪 [Jest - Components Unit Testing]
+- 🟩 [GitHub Calendar Heatmap]
+- 💎 [giscus]
+- 🚨 [GitHub Alerts]
+
+[Skeleton Loading]: https://github.com/dvtng/react-loading-skeleton
+[Next.js 15 with App Router]: https://nextjs.org/
+[Markdown Rendering]: https://github.com/hashicorp/next-mdx-remote
+[Jest - Components Unit Testing]: https://jestjs.io/
+[GitHub Calendar Heatmap]: https://github.com/grubersjoe/react-github-calendar
+[giscus]: https://giscus.app/
+[GitHub Alerts]: https://github.com/chrisweb/rehype-github-alerts
+
+## 🌏 Contributing
+
+[PRs](https://github.com/1chooo/portfolio/pulls) and [Issues](https://github.com/1chooo/portfolio/issues) are welcome! 🫵🏻
+
+Please read the [Contributing Guideline] for details on our code of conduct, and the process for submitting pull requests to us.
+
+[Contributing Guideline]: https://docs.1chooo.com/contributing
+
+## 🔩 Getting Started
+
+```shell
+$ git clone git@github.com:1chooo/1chooo.com.git
+$ cd 1chooo.com
+$ npm install
+$ npm run dev   # Open http://localhost:3000 with your browser to see the result.
+```
+
+## 📲 Contact Info
+
+> **Hugo ChunHo Lin**
+> 
+>   📩 E-mail: <a href="mailto:hugo@1chooo.com">hugo@1chooo.com</a>
+> <br />
+>   🧳 Linkedin: <a href="https://www.linkedin.com/in/1chooo/">Hugo ChunHo Lin</a>
+> <br />
+>   👨🏻‍💻 GitHub: <a href="https://github.com/1chooo">1chooo</a>
+
+## 🪪 License
+
+This work is licensed under a
+[Creative Commons Attribution 4.0 International License][cc-by] by [Hugo ChunHo Lin][1chooo-com].
+
+[cc-by]: http://creativecommons.org/licenses/by/4.0/
+
+1. You are free to use this code as inspiration.
+2. Please do not copy it directly.
+3. Crediting the author is appreciated.
+
+This software can be modified and reused without restriction.
+The original license must be included with any copies of this software.
+If a significant portion of the source code is used, please provide a link back to this repository.
+
+Please remove all of my personal information by running `npm run delete`.
+
+Made with 🖤 by [@1chooo][1chooo-com]
+
+[1chooo-com]: https://1chooo.com
+

--- a/apps/web/src/app/(home)/project/[slug]/page.tsx
+++ b/apps/web/src/app/(home)/project/[slug]/page.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { ViewTransitionsProgressBarLink } from "@/components/progress-bar";
+import ArticleTitle from "@/components/article-title";
+import markdownToHtml from "@/lib/markdownToHtml";
+import { getProjects, getProjectPostBySlug } from "@/lib/api/project";
+import { CMS_NAME } from "@/lib/constants";
+import Balancer from "react-wrap-balancer";
+
+import { cn } from "@1chooo/ui/lib/utils";
+
+import "@/styles/markdown-styles.css";
+
+type Params = {
+  params: Promise<{
+    slug: string;
+  }>;
+};
+
+export default async function Post(props: Params) {
+  const params = await props.params;
+  const post = getProjectPostBySlug(params.slug);
+
+  if (!post) {
+    return notFound();
+  }
+
+  const content = await markdownToHtml(post.content || "");
+
+  return (
+    <div>
+      <article>
+        <ViewTransitionsProgressBarLink href="/project" rel="noopener noreferrer">
+          <ArticleTitle
+            className="text-light-gray hover:text-light-gray-70"
+            title="← Back to Project"
+          />
+        </ViewTransitionsProgressBarLink>
+        <h1 className="font-semibold text-4xl text-white-2 max-w-[650px]">
+          <Balancer>{post.title}</Balancer>
+        </h1>
+        <div className="flex items-center justify-between mt-4 text-sm w-full text-neutral-600 dark:text-neutral-400">
+          <div className="flex items-center space-x-2">
+            <span>
+              {new Date(post.publishedAt).toLocaleDateString("en-us", {
+                month: "long",
+                day: "numeric",
+                year: "numeric",
+              })}
+            </span>
+            <span
+              className="w-1 h-1 bg-current rounded-full"
+              aria-hidden="true"
+            ></span>
+            <span>{post.category.toUpperCase()}</span>
+          </div>
+        </div>
+        <div className="separator"></div>
+        <div className="flex justify-center">
+          <div
+            className={cn(
+              "markdown text-light-gray w-[90%] sm:w-[90%] md:w-[90%] lg:w-[80%] xl:w-[80%]",
+            )}
+            dangerouslySetInnerHTML={{ __html: content }}
+          />
+        </div>
+      </article>
+    </div>
+  );
+}
+
+
+export async function generateMetadata(props: Params): Promise<Metadata> {
+  const params = await props.params;
+  const post = getProjectPostBySlug(params.slug);
+
+  if (!post) {
+    return notFound();
+  }
+
+  const title = `${post.title} | Next.js Blog Example with ${CMS_NAME}`;
+
+  return {
+    title,
+    openGraph: {
+      title,
+      images: [post.ogImage.url],
+    },
+  };
+}
+
+export async function generateStaticParams() {
+  const posts = getProjects();
+
+  return posts.map((post) => ({
+    slug: post.slug,
+  }));
+}

--- a/apps/web/src/app/(home)/project/page.tsx
+++ b/apps/web/src/app/(home)/project/page.tsx
@@ -1,0 +1,63 @@
+import Image from "next/image";
+
+import ArticleTitle from "@/components/article-title";
+import { ViewTransitionsProgressBarLink } from "@/components/progress-bar";
+
+import { getProjects } from "@/lib/api/project";
+
+import config from "@/config";
+import { LuEye } from "react-icons/lu";
+
+const { title } = config;
+
+export const metadata = {
+  title: `Project | ${title}`,
+  description: "Read my thoughts on software development, design, and more.",
+};
+
+export default function Project() {
+  const allProjects = getProjects();
+
+  return (
+    <article>
+      <ArticleTitle title="Hugo's Project" />
+      <section className="projects">
+        <ul className="project-list">
+          {allProjects.map((post) => (
+            <li
+              key={post.slug}
+              className="project-item active"
+              data-category={post.category}
+            >
+              <ViewTransitionsProgressBarLink
+                href={`/project/${post.slug}`}
+                rel="noopener noreferrer"
+              >
+                <figure className="project-img">
+                  <div className="project-item-icon-box">
+                    <LuEye />
+                  </div>
+                  <Image
+                    src={post.coverImage}
+                    alt={post.title || "Portfolio post image"}
+                    width={960}
+                    height={540}
+                    priority
+                    placeholder="blur"
+                    loading="eager"
+                    quality={50}
+                    blurDataURL="https://docs.1chooo.com/images/cover-with-1chooo-com.png"
+                  />
+                </figure>
+                <h3 className="project-title">
+                  {post.title}
+                </h3>
+                <p className="project-category">{post.category}</p>
+              </ViewTransitionsProgressBarLink>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </article>
+  );
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -627,7 +627,6 @@ main {
   color: var(--white-2);
   font-size: var(--fs-5);
   font-weight: var(--fw-400);
-  text-transform: capitalize;
   line-height: 1.3;
 }
 

--- a/apps/web/src/components/layout/vercel-navbar.tsx
+++ b/apps/web/src/components/layout/vercel-navbar.tsx
@@ -24,6 +24,10 @@ export const VercelNavBar = ({ navigationLinks }: VercelNavBarProps) => {
     if (path === "/blog" && currentPath.startsWith("/blog")) return true;
     else if (path === "/portfolio" && currentPath.startsWith("/portfolio"))
       return true;
+    else if (path === "/project" && currentPath.startsWith("/project"))
+      return true;
+    else if (path === "/post" && currentPath.startsWith("/post"))
+      return true;
     return currentPath === path;
   };
 

--- a/apps/web/src/config/index.ts
+++ b/apps/web/src/config/index.ts
@@ -20,7 +20,7 @@ const config: Config = {
   navigationLinks: [
     { path: "/", label: "About" },
     { path: "/resume", label: "Resume" },
-    { path: "/portfolio", label: "Portfolio" },
+    { path: "/project", label: "Project" },
     { path: "/blog", label: "Blog" },
   ],
   contacts: [

--- a/apps/web/src/lib/api/project.ts
+++ b/apps/web/src/lib/api/project.ts
@@ -1,0 +1,28 @@
+import { ProjectPost } from "@/types/project";
+import fs from "fs";
+import matter from "gray-matter";
+import { join } from "path";
+
+const projectPostsDirectory = join(process.cwd(), "_posts", "project");
+
+export function getProjectPostSlugs() {
+  return fs.readdirSync(projectPostsDirectory);
+}
+
+export function getProjectPostBySlug(slug: string) {
+  const realSlug = slug.replace(/\.md$/, "");
+  const fullPath = join(projectPostsDirectory, `${realSlug}.md`);
+  const fileContents = fs.readFileSync(fullPath, "utf8");
+  const { data, content } = matter(fileContents);
+
+  return { ...data, slug: realSlug, content } as ProjectPost;
+}
+
+export function getProjects(): ProjectPost[] {
+  const slugs = getProjectPostSlugs();
+  const posts = slugs
+    .map((slug) => getProjectPostBySlug(slug))
+    // sort posts by date in descending order
+    .sort((post1, post2) => (post1.date > post2.date ? -1 : 1));
+  return posts;
+}

--- a/apps/web/src/types/project.ts
+++ b/apps/web/src/types/project.ts
@@ -1,0 +1,24 @@
+export type Author = {
+  name: string;
+  avatar: string;
+};
+
+export type ProjectPost = {
+  slug: string;
+  title: string;
+  date: string;
+  publishedAt: string;
+  lastModifiedAt: string;
+  coverImage: string;
+  author: Author;
+  /**
+   * @todo let user to customize the color of tags and categories
+   */
+  tags: string[];
+  category: string;
+  excerpt: string;
+  ogImage: {
+    url: string;
+  };
+  content: string;
+};


### PR DESCRIPTION
This pull request introduces a new "Project" section to the website, enabling the display and management of project posts with metadata and markdown content. It includes changes to integrate the new section into the navigation, define the data structure, and implement the necessary API and UI components.

### New "Project" Section Implementation:

* **Project Metadata and Markdown Content**:
  - Added a sample project post in `_posts/project/1chooo-com.md` with metadata (e.g., title, dates, tags) and markdown content for rendering.
  - Defined the `ProjectPost` type in `apps/web/src/types/project.ts` to standardize the structure of project data, including fields such as `title`, `tags`, and `content`.

* **API for Project Posts**:
  - Created functions in `apps/web/src/lib/api/project.ts` to fetch project posts, including `getProjectPostBySlug` for individual posts and `getProjects` for all posts. These functions use `fs` and `gray-matter` to read and parse markdown files.

### UI Enhancements:

* **Project List and Details Pages**:
  - Implemented the `Project` page in `apps/web/src/app/(home)/project/page.tsx` to display a list of projects with titles, categories, and cover images.
  - Added a dynamic `Post` page in `apps/web/src/app/(home)/project/[slug]/page.tsx` to render individual project posts with metadata and markdown content. ([apps/web/src/app/(home)/project/[slug]/page.tsxR1-R99](diffhunk://#diff-30428a5349af2b0a06add55067bfa00fe4c3fb09c1ebf9e8c81a72d7f199206dR1-R99))

* **Navigation Updates**:
  - Updated the navigation links in `apps/web/src/config/index.ts` to replace "Portfolio" with "Project".
  - Enhanced the `VercelNavBar` component to highlight the "Project" section when the user is on related pages.

### Minor Adjustments:

* **Global Styles**:
  - Removed the `text-transform: capitalize;` rule in `apps/web/src/app/globals.css` to ensure consistent text styling.


resolved: #1208 