### PR TITLE
chore(deps): upgrade zod to version 4.0.5 across multiple packages (#1341)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -89,7 +89,7 @@
     "tailwind-merge": "^3.2.0",
     "tailwindcss-animate": "^1.0.7",
     "unist-util-visit": "^5.0.0",
-    "zod": "3.25.76"
+    "zod": "4.0.5"
   },
   "browserslist": {
     "production": [

--- a/apps/web/src/app/api/views/blog/route.ts
+++ b/apps/web/src/app/api/views/blog/route.ts
@@ -75,7 +75,7 @@ export async function POST(request: NextRequest) {
     // 如果是 Zod 驗證錯誤
     if (error instanceof z.ZodError) {
       const errorResponse = ErrorResponseSchema.parse({
-        error: `Validation error: ${error.errors.map((e) => e.message).join(", ")}`,
+        error: `Validation error: ${error.issues.map((e) => e.message).join(", ")}`,
       });
       return NextResponse.json(errorResponse, { status: 400 });
     }
@@ -115,7 +115,7 @@ export async function GET(request: NextRequest) {
     // 如果是 Zod 驗證錯誤
     if (error instanceof z.ZodError) {
       const errorResponse = ErrorResponseSchema.parse({
-        error: `Validation error: ${error.errors.map((e) => e.message).join(", ")}`,
+        error: `Validation error: ${error.issues.map((e) => e.message).join(", ")}`,
       });
       return NextResponse.json(errorResponse, { status: 400 });
     }

--- a/apps/web/src/app/api/views/blog/route.ts
+++ b/apps/web/src/app/api/views/blog/route.ts
@@ -11,7 +11,6 @@ export async function POST(request: NextRequest) {
   try {
     const rawBody = await request.json();
 
-    // 驗證請求 body
     const validatedBody = ViewRequestSchema.parse(rawBody);
     const { slug } = validatedBody;
 
@@ -72,10 +71,11 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error("Error updating views:", error);
 
-    // 如果是 Zod 驗證錯誤
-    if (error instanceof z.ZodError) {
+    // Handle Zod validation errors
+    if (error && typeof error === "object" && "issues" in error) {
+      const zodError = error as z.ZodError;
       const errorResponse = ErrorResponseSchema.parse({
-        error: `Validation error: ${error.issues.map((e) => e.message).join(", ")}`,
+        error: `Validation error: ${zodError.issues.map((issue) => issue.message).join(", ")}`,
       });
       return NextResponse.json(errorResponse, { status: 400 });
     }
@@ -112,10 +112,11 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     console.error("Error fetching views:", error);
 
-    // 如果是 Zod 驗證錯誤
-    if (error instanceof z.ZodError) {
+    // Handle Zod validation errors
+    if (error && typeof error === "object" && "issues" in error) {
+      const zodError = error as z.ZodError;
       const errorResponse = ErrorResponseSchema.parse({
-        error: `Validation error: ${error.issues.map((e) => e.message).join(", ")}`,
+        error: `Validation error: ${zodError.issues.map((issue) => issue.message).join(", ")}`,
       });
       return NextResponse.json(errorResponse, { status: 400 });
     }

--- a/apps/web/src/app/api/views/project/route.ts
+++ b/apps/web/src/app/api/views/project/route.ts
@@ -11,7 +11,6 @@ export async function POST(request: NextRequest) {
   try {
     const rawBody = await request.json();
 
-    // 驗證請求 body
     const validatedBody = ViewRequestSchema.parse(rawBody);
     const { slug } = validatedBody;
 
@@ -71,9 +70,11 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error("Error updating views:", error);
 
-    if (error instanceof z.ZodError) {
+    // Handle Zod validation errors
+    if (error && typeof error === "object" && "issues" in error) {
+      const zodError = error as z.ZodError;
       const errorResponse = ErrorResponseSchema.parse({
-        error: `Validation error: ${error.issues.map((e) => e.message).join(", ")}`,
+        error: `Validation error: ${zodError.issues.map((issue) => issue.message).join(", ")}`,
       });
       return NextResponse.json(errorResponse, { status: 400 });
     }
@@ -109,9 +110,11 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     console.error("Error fetching views:", error);
 
-    if (error instanceof z.ZodError) {
+    // Handle Zod validation errors
+    if (error && typeof error === "object" && "issues" in error) {
+      const zodError = error as z.ZodError;
       const errorResponse = ErrorResponseSchema.parse({
-        error: `Validation error: ${error.issues.map((e) => e.message).join(", ")}`,
+        error: `Validation error: ${zodError.issues.map((issue) => issue.message).join(", ")}`,
       });
       return NextResponse.json(errorResponse, { status: 400 });
     }

--- a/apps/web/src/app/api/views/project/route.ts
+++ b/apps/web/src/app/api/views/project/route.ts
@@ -73,7 +73,7 @@ export async function POST(request: NextRequest) {
 
     if (error instanceof z.ZodError) {
       const errorResponse = ErrorResponseSchema.parse({
-        error: `Validation error: ${error.errors.map((e) => e.message).join(", ")}`,
+        error: `Validation error: ${error.issues.map((e) => e.message).join(", ")}`,
       });
       return NextResponse.json(errorResponse, { status: 400 });
     }
@@ -111,7 +111,7 @@ export async function GET(request: NextRequest) {
 
     if (error instanceof z.ZodError) {
       const errorResponse = ErrorResponseSchema.parse({
-        error: `Validation error: ${error.errors.map((e) => e.message).join(", ")}`,
+        error: `Validation error: ${error.issues.map((e) => e.message).join(", ")}`,
       });
       return NextResponse.json(errorResponse, { status: 400 });
     }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -31,7 +31,7 @@
     "react-dom": "19.1.0",
     "tailwind-merge": "^3.2.0",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "3.25.76",
+    "zod": "4.0.5",
     "eslint": "9.31.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,8 +308,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: 4.0.5
+        version: 4.0.5
     devDependencies:
       '@1chooo/eslint-config':
         specifier: workspace:^
@@ -523,8 +523,8 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.1.11)
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: 4.0.5
+        version: 4.0.5
     devDependencies:
       '@1chooo/eslint-config':
         specifier: workspace:*
@@ -8168,6 +8168,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.0.5:
+    resolution: {integrity: sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==}
 
   zustand@5.0.6:
     resolution: {integrity: sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==}
@@ -17180,6 +17183,8 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.0.5: {}
 
   zustand@5.0.6(@types/react@19.1.8)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0)):
     optionalDependencies:


### PR DESCRIPTION
This pull request updates the `zod` library to version 4.0.5 across multiple files and improves error handling in API routes by refining the way Zod validation errors are processed. Below are the key changes grouped by theme:

### Dependency Updates:
* Updated `zod` from version `3.25.76` to `4.0.5` in `apps/web/package.json` and `packages/ui/package.json`. [[1]](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L92-R92) [[2]](diffhunk://#diff-1ae5a5e8c23bd3bc31ea590a9cbe48eb9ad3bbddc0fb5732d08c04a53c8ad51dL34-R34)
* Updated `zod` references in `pnpm-lock.yaml` to reflect the new version, including its specifier, version, and integrity hash. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL311-R312) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL526-R527) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR8172-R8174) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR17187-R17188)

### API Error Handling Improvements:
* In `apps/web/src/app/api/views/blog/route.ts` and `apps/web/src/app/api/views/project/route.ts`, replaced `error instanceof z.ZodError` checks with a more robust validation for Zod errors (`error && typeof error === "object" && "issues" in error`). This ensures better compatibility with the updated `zod` library. [[1]](diffhunk://#diff-d8757f8c4b9b9c6919c4bda33d6c53e64c90be9b01a97c573429d59e3e1351cfL75-R78) [[2]](diffhunk://#diff-d8757f8c4b9b9c6919c4bda33d6c53e64c90be9b01a97c573429d59e3e1351cfL115-R119) [[3]](diffhunk://#diff-b7df06fcb9a78b569b0c31209ff0c6b3990bedcedde41eb907d78dab6cd13ee0L74-R77) [[4]](diffhunk://#diff-b7df06fcb9a78b569b0c31209ff0c6b3990bedcedde41eb907d78dab6cd13ee0L112-R117)
* Updated error message generation to use `zodError.issues.map` instead of `error.errors.map`, aligning with the updated Zod API. [[1]](diffhunk://#diff-d8757f8c4b9b9c6919c4bda33d6c53e64c90be9b01a97c573429d59e3e1351cfL75-R78) [[2]](diffhunk://#diff-d8757f8c4b9b9c6919c4bda33d6c53e64c90be9b01a97c573429d59e3e1351cfL115-R119) [[3]](diffhunk://#diff-b7df06fcb9a78b569b0c31209ff0c6b3990bedcedde41eb907d78dab6cd13ee0L74-R77) [[4]](diffhunk://#diff-b7df06fcb9a78b569b0c31209ff0c6b3990bedcedde41eb907d78dab6cd13ee0L112-R117)

### Code Cleanup:
* Removed inline comments in Chinese from the `POST` methods in `apps/web/src/app/api/views/blog/route.ts` and `apps/web/src/app/api/views/project/route.ts`. [[1]](diffhunk://#diff-d8757f8c4b9b9c6919c4bda33d6c53e64c90be9b01a97c573429d59e3e1351cfL14) [[2]](diffhunk://#diff-b7df06fcb9a78b569b0c31209ff0c6b3990bedcedde41eb907d78dab6cd13ee0L14)