### PR TITLE
feat(web): add selected project in Home and remove GitHub Calendar (#485)

### DIFF
--- a/apps/web/src/app/(home)/page.tsx
+++ b/apps/web/src/app/(home)/page.tsx
@@ -2,32 +2,24 @@ import dynamic from "next/dynamic";
 
 import PageTitle from "@/components/page-title";
 import { MyWritings } from "@/components/about/my-writings";
-import { BlurFade } from "@/components/magicui/blur-fade";
 import { FadeLeft, FadeUp } from "@/components/animations/animations";
-import GitHubCalendar from "@1chooo/github-calendar";
-import { ThemeInput } from "@1chooo/activity-calendar/types";
 
 import { getBlogPosts, getCleanMdxContentFromPath } from "@/lib/api/mdx";
-import { ABOUT_PATH, BLOG_DIRECTORY } from "@/lib/constants";
+import { ABOUT_PATH, BLOG_DIRECTORY, PROJECT_DIRECTORY } from "@/lib/constants";
 
 import config from "@/config";
 
 const AboutSection = dynamic(() => import("@/components/section/about"));
 const Mdx = dynamic(() => import("@/components/mdx"));
-
-const { about } = config;
-const { firstName, lastName, preferredName, githubUsername } = about;
+const LatestArticles = dynamic(() => import("@/components/about/latest-articles"));
 
 function About() {
-  const allPosts = getBlogPosts(BLOG_DIRECTORY);
-  const yellowTheme: ThemeInput = {
-    light: ["#EBEBEB", "#FFDA6B"],
-    dark: ["#383838", "#FFDA6B"],
-  };
+  const blogs = getBlogPosts(BLOG_DIRECTORY);
+  const projects = getBlogPosts(PROJECT_DIRECTORY);
 
-  let title = preferredName
-    ? `About ${preferredName} 👨🏻‍💻`
-    : `About ${firstName} ${lastName} 👨🏻‍💻`;
+  let title = config.about.preferredName
+    ? `About ${config.about.preferredName} 👨🏻‍💻`
+    : `About ${config.about.firstName} ${config.about.lastName} 👨🏻‍💻`;
 
   return (
     <article>
@@ -39,27 +31,12 @@ function About() {
         <Mdx source={getCleanMdxContentFromPath(ABOUT_PATH)} />
       </FadeLeft>
 
-      <AboutSection id="github-calendar">
-        <BlurFade inView delay={0.4} direction="up">
-          <section id="github-calendar" className="text-light-gray">
-            {githubUsername && (
-              <GitHubCalendar
-                username={githubUsername}
-                blockSize={12}
-                blockMargin={4}
-                colorScheme="dark"
-                blockRadius={2}
-                fontSize={14}
-                style={{ fontWeight: "bold" }}
-                theme={yellowTheme}
-              />
-            )}
-          </section>
-        </BlurFade>
+      <AboutSection id="selected-project" title="Selected Project">
+        <LatestArticles posts={projects} route="/project"/>
       </AboutSection>
 
       <AboutSection id="my-writings" title="My Writings">
-        <MyWritings count={3} posts={allPosts} />
+        <MyWritings count={3} posts={blogs} />
       </AboutSection>
     </article>
   );

--- a/apps/web/src/components/about/latest-articles.tsx
+++ b/apps/web/src/components/about/latest-articles.tsx
@@ -18,9 +18,10 @@ import styles from "@/styles/about/latest-articles.module.css";
 
 interface LatestArticlesProps {
   posts: BlogPost[];
+  route: string;
 }
 
-function LatestArticles({ posts }: LatestArticlesProps) {
+function LatestArticles({ posts, route }: LatestArticlesProps) {
   const [isMounted, setIsMounted] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const [visiblePosts, setVisiblePosts] = useState<BlogPost[]>([]);
@@ -59,7 +60,7 @@ function LatestArticles({ posts }: LatestArticlesProps) {
               className={cn(styles["latest-post"], "group active")}
             >
               <ViewTransitionsProgressBarLink
-                href={`/blog/${post.slug}`}
+                href={`/${route}/${post.slug}`}
                 rel="noopener noreferrer"
               >
                 <figure className={cn(styles["latest-post-img"])}>
@@ -82,7 +83,7 @@ function LatestArticles({ posts }: LatestArticlesProps) {
                     loading="eager"
                   />
                 </figure>
-                <h3 className="ml-[10px] text-white-2 text-base font-normal capitalize leading-[1.3] group-hover:text-orange-yellow-crayola group-hover:font-bold">
+                <h3 className="ml-[10px] text-white-2 text-base font-normal leading-[1.3] group-hover:text-orange-yellow-crayola group-hover:font-bold">
                   {post.title}
                 </h3>
               </ViewTransitionsProgressBarLink>
@@ -98,9 +99,9 @@ function LatestArticles({ posts }: LatestArticlesProps) {
               "group rounded-full border border-black/5 bg-neutral-100 text-base text-white transition-all ease-in hover:cursor-pointer hover:bg-neutral-200 dark:border-white/5 dark:bg-neutral-900 dark:hover:bg-neutral-800",
             )}
           >
-            <ViewTransitionsProgressBarLink href="/blog">
+            <ViewTransitionsProgressBarLink href={route}>
               <AnimatedShinyText className="inline-flex items-center justify-center px-4 py-1 transition ease-out hover:text-neutral-600 hover:duration-300 hover:dark:text-neutral-400">
-                <span>✨ See More Posts</span>
+                <span>✨ See More Projects</span>
                 <ArrowRight className="ml-1 size-3 transition-transform duration-300 ease-in-out group-hover:translate-x-0.5" />
               </AnimatedShinyText>
             </ViewTransitionsProgressBarLink>


### PR DESCRIPTION

- resolved: #485
This pull request refactors the "About" page to enhance project and blog post management. It introduces a new `LatestArticles` component for displaying selected projects and updates the existing blog-related functionality to improve reusability and maintainability. Key changes are grouped below:

### Refactoring and New Features:
* Replaced the GitHub calendar section with a "Selected Project" section on the "About" page, using the new `LatestArticles` component to display selected projects.
* Updated the `LatestArticles` component to accept a `route` prop, enabling dynamic routing for different content types like blogs and projects. [[1]](diffhunk://#diff-e8b74c04252a03efb69dd63191770f014cf8ac6bfd55cb5d5ee8f7d285e43e85R21-R24) [[2]](diffhunk://#diff-e8b74c04252a03efb69dd63191770f014cf8ac6bfd55cb5d5ee8f7d285e43e85L62-R63) [[3]](diffhunk://#diff-e8b74c04252a03efb69dd63191770f014cf8ac6bfd55cb5d5ee8f7d285e43e85L101-R104)

### Code Cleanup and Simplification:
* Removed unused imports such as `GitHubCalendar`, `BlurFade`, and `ThemeInput` from `apps/web/src/app/(home)/page.tsx`.
* Simplified the `title` logic in the "About" page by directly accessing `config.about` properties.

### Minor Adjustments:
* Updated text and styles in the `LatestArticles` component to align with the new "Selected Project" section, including changing "See More Posts" to "See More Projects."
* Fixed a minor formatting issue in the `LatestArticles` component's post title rendering.