### PR TITLE
refactor(web): simplify sidebar by removing toggle functionality

### DIFF
--- a/apps/web/src/app/(home)/layout.tsx
+++ b/apps/web/src/app/(home)/layout.tsx
@@ -87,7 +87,7 @@ function HomeLayout({ children }: { readonly children: React.ReactNode }) {
               </div>
             </main>
 
-            <main className="lg:hidden xl:hidden 2xl:hidden">
+            <main className="xl:hidden 2xl:hidden">
               <article>
                 <SidebarFooter
                   avatar={avatar}

--- a/apps/web/src/app/(home)/layout.tsx
+++ b/apps/web/src/app/(home)/layout.tsx
@@ -5,6 +5,7 @@ import { ViewTransitions } from "next-view-transitions";
 
 import { NavBar } from "@/components/layout/nav-bar";
 import Sidebar from "@/components/layout/sidebar";
+import SidebarFooter from "@/components/layout/sidebar-footer";
 import Hello from "@/components/hello";
 import { ProgressBar } from "@/components/progress-bar";
 import { GoogleAnalytic } from "@/components/analytics/google";
@@ -84,6 +85,20 @@ function HomeLayout({ children }: { readonly children: React.ReactNode }) {
                 <NavBar navigationLinks={navigationLinks} />
                 {children}
               </div>
+            </main>
+
+            <main className="lg:hidden xl:hidden 2xl:hidden">
+              <article>
+                <SidebarFooter
+                  avatar={avatar}
+                  firstName={firstName}
+                  lastName={lastName}
+                  middleName={middleName}
+                  preferredName={preferredName}
+                  status={status}
+                  contacts={contacts}
+                />
+              </article>
             </main>
           </ProgressBar>
           <Script

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -242,7 +242,7 @@ article {
 
 main {
   margin: 15px 12px;
-  margin-bottom: 75px;
+  /* margin-bottom: 75px; */
   min-width: 259px;
 }
 
@@ -535,13 +535,9 @@ textarea.form-input::-webkit-resizer {
     padding: 30px;
   }
 
-  /**
-  * #MAIN
-  */
-
   main {
     margin-top: 60px;
-    margin-bottom: 100px;
+    /* margin-bottom: 100px; */
   }
 
   /* clients */
@@ -660,9 +656,9 @@ textarea.form-input::-webkit-resizer {
     box-shadow: var(--shadow-5);
   }
 
-  main {
+  /* main {
     margin-bottom: 60px;
-  }
+  } */
 
   .main-content {
     position: relative;

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -4,40 +4,28 @@
 
 :root {
   /* gradient */
-  --bg-gradient-onyx: linear-gradient(
-    to bottom right,
-    hsl(240, 1%, 25%) 3%,
-    hsl(0, 0%, 19%) 97%
-  );
+  --bg-gradient-onyx: linear-gradient(to bottom right,
+      hsl(240, 1%, 25%) 3%,
+      hsl(0, 0%, 19%) 97%);
   --bg-gradient-jet:
-    linear-gradient(
-      to bottom right,
+    linear-gradient(to bottom right,
       hsla(240, 1%, 18%, 0.251) 0%,
-      hsla(240, 2%, 11%, 0) 100%
-    ),
+      hsla(240, 2%, 11%, 0) 100%),
     hsl(240, 2%, 13%);
-  --bg-gradient-yellow-1: linear-gradient(
-    to bottom right,
-    hsl(45, 100%, 71%) 0%,
-    hsla(36, 100%, 69%, 0) 50%
-  );
+  --bg-gradient-yellow-1: linear-gradient(to bottom right,
+      hsl(45, 100%, 71%) 0%,
+      hsla(36, 100%, 69%, 0) 50%);
   --bg-gradient-yellow-2:
-    linear-gradient(
-      135deg,
+    linear-gradient(135deg,
       hsla(45, 100%, 71%, 0.251) 0%,
-      hsla(35, 100%, 68%, 0) 59.86%
-    ),
+      hsla(35, 100%, 68%, 0) 59.86%),
     hsl(240, 2%, 13%);
-  --border-gradient-onyx: linear-gradient(
-    to bottom right,
-    hsl(0, 0%, 25%) 0%,
-    hsla(0, 0%, 25%, 0) 50%
-  );
-  --text-gradient-yellow: linear-gradient(
-    to right,
-    hsl(45, 100%, 72%),
-    hsl(35, 100%, 68%)
-  );
+  --border-gradient-onyx: linear-gradient(to bottom right,
+      hsl(0, 0%, 25%) 0%,
+      hsla(0, 0%, 25%, 0) 50%);
+  --text-gradient-yellow: linear-gradient(to right,
+      hsl(45, 100%, 72%),
+      hsl(35, 100%, 68%));
 
   /* solid */
   --jet: hsl(0, 0%, 22%);
@@ -246,44 +234,6 @@ main {
   min-width: 259px;
 }
 
-/**
-* #clients 
-*/
-
-.clients {
-  margin-bottom: 15px;
-}
-
-.clients-list {
-  display: flex;
-  justify-content: flex-start;
-  align-items: flex-start;
-  gap: 15px;
-  margin: 0 -15px;
-  padding: 25px;
-  padding-bottom: 25px;
-  overflow-x: auto;
-  scroll-behavior: smooth;
-  overscroll-behavior-inline: contain;
-  scroll-snap-type: inline mandatory;
-  scroll-padding-inline: 25px;
-}
-
-.clients-item {
-  min-width: 50%;
-  scroll-snap-align: start;
-}
-
-.clients-item img {
-  width: 100%;
-  filter: grayscale(1);
-  transition: var(--transition-1);
-}
-
-.clients-item img:hover {
-  filter: grayscale(0);
-}
-
 /*-----------------------------------*\
   #PORTFOLIO
 \*-----------------------------------*/
@@ -330,7 +280,7 @@ main {
   transition: 0.15s ease-in-out;
 }
 
-.filter-select.active + .select-list {
+.filter-select.active+.select-list {
   opacity: 1;
   visibility: visible;
   pointer-events: all;
@@ -470,38 +420,6 @@ textarea.form-input::-webkit-resizer {
   background: var(--bg-gradient-jet);
 }
 
-/*-----------------------------------*\
-  #RESPONSIVE
-\*-----------------------------------*/
-
-/**
-* responsive larger than 375px screen
-*/
-
-@media (min-width: 375px) {
-  /**
-  * client
-  */
-
-  .clients-item {
-    min-width: calc(33.33% - 10px);
-  }
-}
-
-/**
-* responsive larger than 450px screen
-*/
-
-@media (min-width: 450px) {
-  /**
-  * client
-  */
-
-  .clients-item {
-    min-width: calc(33.33% - 10px);
-  }
-}
-
 /**
 * responsive larger than 580px screen
 */
@@ -538,19 +456,6 @@ textarea.form-input::-webkit-resizer {
   main {
     margin-top: 60px;
     /* margin-bottom: 100px; */
-  }
-
-  /* clients */
-
-  .clients-list {
-    gap: 50px;
-    margin: 0 -30px;
-    padding: 45px;
-    scroll-padding-inline: 45px;
-  }
-
-  .clients-item {
-    min-width: calc(33.33% - 35px);
   }
 
   /**
@@ -664,10 +569,6 @@ textarea.form-input::-webkit-resizer {
     position: relative;
     width: max-content;
     margin: auto;
-  }
-
-  .clients-item {
-    min-width: calc(25% - 38px);
   }
 }
 

--- a/apps/web/src/components/about/posts-loop.tsx
+++ b/apps/web/src/components/about/posts-loop.tsx
@@ -50,7 +50,7 @@ function PostsLoop({ count, posts }: BlogPostsProps) {
     }
     // Google Analytics tracking
     sendGTMEvent({
-      event: 'clickMyWritings',
+      event: 'click_my_writings',
       value: slug,
       post_title: title,
     });

--- a/apps/web/src/components/about/selected-projects.tsx
+++ b/apps/web/src/components/about/selected-projects.tsx
@@ -56,7 +56,7 @@ function SelectedProjects({
                 }
                 // Google Analytics tracking
                 sendGTMEvent({
-                  event: 'clickSelectedProjects',
+                  event: 'click_selected_projects',
                   value: post.slug,
                   project_title: post.title,
                 });

--- a/apps/web/src/components/layout/sidebar-footer.tsx
+++ b/apps/web/src/components/layout/sidebar-footer.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import Image from "next/image";
 
 import Footer from "@/components/layout/footer";
 import IconBox from "@/components/icon-box";
@@ -8,7 +7,7 @@ import type { Contact } from "@/types/config";
 
 import styles from "@/styles/layout/sidebar.module.css";
 
-interface SidebarProps {
+interface SidebarFooterProps {
   avatar: string;
   firstName: string;
   lastName: string;
@@ -18,29 +17,17 @@ interface SidebarProps {
   contacts?: Contact[];
 }
 
-function Sidebar({
-  avatar,
+function SidebarFooter({
   firstName,
   lastName,
   preferredName,
   status,
   contacts,
-}: SidebarProps) {
+}: SidebarFooterProps) {
+
   return (
-    <aside className={styles.sidebar} data-sidebar>
-      <div className={styles.sidebarInfo}>
-        <figure className={styles.avatarBox}>
-          <Image
-            id={`${firstName} (${preferredName}) ${lastName}`}
-            src={avatar}
-            alt={`${firstName} (${preferredName}) ${lastName}`}
-            width={150}
-            height={150}
-            quality={50}
-            loading="eager"
-            priority
-          />
-        </figure>
+    <aside className={styles.sidebarFooter} data-sidebar-footer>
+      <div className={styles.sidebarFooterInfo}>
         <div>
           <h1
             className={styles.name}
@@ -52,7 +39,7 @@ function Sidebar({
         </div>
       </div>
 
-      <div className={styles.sidebarInfoMore}>
+      <div className={styles.sidebarFooterInfoMore}>
         <div className={styles.separator}></div>
         <ul className={styles.contactsList}>
           {contacts?.map((contact, index) => {
@@ -89,5 +76,5 @@ function Sidebar({
   );
 }
 
-export default Sidebar;
-export { Sidebar };
+export default SidebarFooter;
+export { SidebarFooter };

--- a/apps/web/src/styles/layout/sidebar.module.css
+++ b/apps/web/src/styles/layout/sidebar.module.css
@@ -6,25 +6,11 @@
   box-shadow: var(--shadow-1);
   z-index: 1;
   margin-bottom: 15px;
-  max-height: 112px;
-  overflow: hidden;
-  transition: var(--transition-2);
-}
-
-.sidebarActive {
-  max-height: 40rem;
 }
 
 /* Sidebar info more section */
 .sidebarInfoMore {
-  opacity: 0;
-  visibility: hidden;
-  transition: var(--transition-2);
-}
-
-.sidebarActive .sidebarInfoMore {
-  opacity: 1;
-  visibility: visible;
+  display: none;
 }
 
 .sidebarInfo {
@@ -86,43 +72,7 @@
   margin-bottom: 1rem;
 }
 
-.infoMoreBtn {
-  position: absolute;
-  top: -15px;
-  right: -15px;
-  border-radius: 0 15px;
-  font-size: 13px;
-  color: var(--orange-yellow-crayola);
-  background: var(--border-gradient-onyx);
-  padding: 10px;
-  box-shadow: var(--shadow-2);
-  transition: var(--transition-1);
-  z-index: 1;
-}
 
-.infoMoreBtn::before {
-  content: "";
-  position: absolute;
-  inset: 1px;
-  border-radius: inherit;
-  background: var(--bg-gradient-jet);
-  transition: var(--transition-1);
-  z-index: -1;
-}
-
-.infoMoreBtn:hover,
-.infoMoreBtn:focus {
-  background: var(--bg-gradient-yellow-1);
-}
-
-.infoMoreBtn:hover::before,
-.infoMoreBtn:focus::before {
-  background: var(--bg-gradient-yellow-2);
-}
-
-.infoMoreBtn span {
-  display: none;
-}
 
 .separator {
   width: 100%;
@@ -233,21 +183,6 @@
     gap: 20px;
   }
 
-  .infoMoreBtn {
-    top: -30px;
-    right: -30px;
-    padding: 10px 15px;
-  }
-
-  .infoMoreBtn span {
-    display: block;
-    font-size: var(--fs-8);
-  }
-
-  .infoMoreBtn svg {
-    display: none;
-  }
-
   .separator {
     margin: 32px 0;
   }
@@ -256,12 +191,7 @@
     width: 520px;
     margin-inline: auto;
     padding: 30px;
-    max-height: 180px;
     margin-bottom: 30px;
-  }
-
-  .sidebarActive {
-    max-height: 40rem;
   }
 }
 
@@ -271,24 +201,12 @@
     gap: 30px 15px;
   }
 
-  .infoMoreBtn svg {
-    display: none;
-  }
-
   .sidebar {
     width: 700px;
-  }
-
-  .sidebarActive {
-    max-height: 60rem;
   }
 }
 
 @media (min-width: 1024px) {
-  .infoMoreBtn svg {
-    display: none;
-  }
-
   .sidebar {
     width: 950px;
     box-shadow: var(--shadow-5);
@@ -318,10 +236,6 @@
     grid-template-columns: 1fr;
   }
 
-  .infoMoreBtn {
-    display: none;
-  }
-
   .separator:last-of-type {
     margin-top: 1rem;
     margin-bottom: 1rem;
@@ -339,7 +253,6 @@
   }
 
   .sidebarInfoMore {
-    opacity: 1;
-    visibility: visible;
+    display: block;
   }
 }


### PR DESCRIPTION
- Remove client-side state management (useState, useRef) from Sidebar
- Remove toggle button and associated animations/transitions
- Create SidebarFooter component for mobile/tablet layouts
- Desktop (≥1250px): full sidebar with all contact info
- Mobile/Tablet (<1250px): basic sidebar + footer section at page bottom
- Clean up unused CSS for toggle button (.infoMoreBtn, .sidebarActive)
- Simplify .sidebarInfoMore visibility with display property
- Standardize analytics event names (snake_case)
- Remove unnecessary margin-bottom rules from globals.css

BREAKING CHANGE: Sidebar no longer has interactive toggle on mobile. Contact information now appears in footer section on mobile/tablet devices.

- closed: #1506