### PR TITLE
refactor(web): replace duplicate main element with semantic footer (#1508) (#1511)

### DIFF
--- a/apps/web/src/app/(home)/layout.tsx
+++ b/apps/web/src/app/(home)/layout.tsx
@@ -5,7 +5,7 @@ import { ViewTransitions } from "next-view-transitions";
 
 import { NavBar } from "@/components/layout/nav-bar";
 import Sidebar from "@/components/layout/sidebar";
-import SidebarFooter from "@/components/layout/sidebar-footer";
+import MobileFooter from "@/components/layout/mobile-footer";
 import Hello from "@/components/hello";
 import { ProgressBar } from "@/components/progress-bar";
 import { GoogleAnalytic } from "@/components/analytics/google";
@@ -87,19 +87,15 @@ function HomeLayout({ children }: { readonly children: React.ReactNode }) {
               </div>
             </main>
 
-            <main className="xl:hidden 2xl:hidden">
-              <article>
-                <SidebarFooter
-                  avatar={avatar}
-                  firstName={firstName}
-                  lastName={lastName}
-                  middleName={middleName}
-                  preferredName={preferredName}
-                  status={status}
-                  contacts={contacts}
-                />
-              </article>
-            </main>
+            <MobileFooter
+              avatar={avatar}
+              firstName={firstName}
+              lastName={lastName}
+              middleName={middleName}
+              preferredName={preferredName}
+              status={status}
+              contacts={contacts}
+            />
           </ProgressBar>
           <Script
             id="application/ld+json"

--- a/apps/web/src/components/layout/mobile-footer.tsx
+++ b/apps/web/src/components/layout/mobile-footer.tsx
@@ -7,7 +7,7 @@ import type { Contact } from "@/types/config";
 
 import styles from "@/styles/layout/sidebar.module.css";
 
-interface SidebarFooterProps {
+interface MobileFooterProps {
   avatar: string;
   firstName: string;
   lastName: string;
@@ -17,16 +17,18 @@ interface SidebarFooterProps {
   contacts?: Contact[];
 }
 
-function SidebarFooter({
+function MobileFooter({
   firstName,
   lastName,
   preferredName,
   status,
   contacts,
-}: SidebarFooterProps) {
+}: MobileFooterProps) {
 
   return (
-    <aside className={styles.sidebarFooter} data-sidebar-footer>
+    <footer className={styles.mobileFooterWrapper}>
+      <article className={styles.mobileFooterArticle}>
+        <aside className={styles.sidebarFooter} data-sidebar-footer>
       <div className={styles.sidebarFooterInfo}>
         <div>
           <h1
@@ -72,9 +74,11 @@ function SidebarFooter({
         <div className={styles.separator}></div>
         <Footer />
       </div>
-    </aside>
+        </aside>
+      </article>
+    </footer>
   );
 }
 
-export default SidebarFooter;
-export { SidebarFooter };
+export default MobileFooter;
+export { MobileFooter };

--- a/apps/web/src/styles/layout/sidebar.module.css
+++ b/apps/web/src/styles/layout/sidebar.module.css
@@ -213,7 +213,28 @@
   }
 }
 
+.mobileFooterWrapper {
+  margin: 15px 12px;
+  min-width: 259px;
+  margin-bottom: 4rem;
+}
+
+.mobileFooterArticle {
+  background: var(--eerie-black-2);
+  border: 1px solid var(--jet);
+  border-radius: 20px;
+  padding: 15px;
+  box-shadow: var(--shadow-1);
+  z-index: 1;
+  display: block;
+  animation: fade 0.5s ease backwards;
+}
+
 @media (min-width: 1250px) {
+  .mobileFooterWrapper {
+    display: none;
+  }
+
   .sidebarInfo {
     flex-direction: column;
   }


### PR DESCRIPTION
- Rename SidebarFooter → MobileFooter
- Use <footer> element instead of second <main>
- Add responsive styles for mobile footer wrapper
- Maintain visual appearance with article wrapper styling

- resolved: #1508
- fixed: #1511